### PR TITLE
Modified Redis Health Check

### DIFF
--- a/app/main/controller/healthcheck_controller.py
+++ b/app/main/controller/healthcheck_controller.py
@@ -41,8 +41,7 @@ class HealthcheckResource(Resource):
     # Redis
     try:
       r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
-      # FIXME Redis database is not being tested by info()
-      r.info()
+      r.ping()
       result['REDIS'] = True
     except Exception as e:
       result['REDIS'] = str(e)

--- a/app/main/controller/healthcheck_controller.py
+++ b/app/main/controller/healthcheck_controller.py
@@ -41,8 +41,7 @@ class HealthcheckResource(Resource):
     # Redis
     try:
       r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
-      r.ping()
-      result['REDIS'] = True
+      result['REDIS'] = r.ping()
     except Exception as e:
       result['REDIS'] = str(e)
 


### PR DESCRIPTION
Line - https://github.com/meedan/alegre/blob/develop/app/main/controller/healthcheck_controller.py#L44

`# FIXME Redis database is not being tested by info()`

Why the change from `info()` to `ping()` is necessary?

1. The purpose of healthcheck is to check if the redis cluster/server is up and running. You don't need any other info than `True/Exception`. 
2. By default, redis has 16 databases, which can be addressed by their indexes starting from 0 and ending at 15. If any value other than `None`(defaults to 0) and 0 to 15 are given, `ping()` will raise a `ResponseError: DB Index is out of range` which is handled in the `except` block
3. The return value of `ping()` is `True` if the connection is fine with checking database details. No need to assign `True` explicitly

