### PR TITLE
Deploy the alegre task updates before the model updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,12 +95,15 @@ deploy_live:
     - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/alegre/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/alegre/##' > env.live.names
-    - for NAME in `cat env.live.names`; do echo -n "-s live-alegre-sbert $NAME /live/alegre/$NAME " >> live-alegre-sbert.env.args; done
-    - echo -n "-s live-alegre-sbert GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-alegre-sbert.env.args
-    - ecs deploy ecs-live  live-alegre-sbert --diff --image live-alegre-sbert $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e live-alegre-sbert APP alegre -e live-alegre-sbert DEPLOY_ENV live -e live-alegre-sbert ALEGRE_PORT 8000 --exclusive-secrets `cat live-alegre-sbert.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-alegre-c $NAME /live/alegre/$NAME " >> live-alegre-c.env.args; done
     - echo -n "-s live-alegre-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-alegre-c.env.args
     - ecs deploy ecs-live  live-alegre --image live-alegre-c $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e live-alegre-c APP alegre -e live-alegre-c DEPLOY_ENV live -e live-alegre-c ALEGRE_PORT 8000 --exclusive-secrets `cat live-alegre-c.env.args`
+    - for NAME in `cat env.live.names`; do echo -n "-s live-alegre-indiansbert $NAME /live/alegre/$NAME " >> live-alegre-indiansbert.env.args; done
+    - echo -n "-s live-alegre-indiansbert GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-alegre-indiansbert.env.args
+    - ecs deploy ecs-live  live-alegre-indiansbert --diff --image live-alegre-indiansbert $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e live-alegre-indiansbert MODEL_NAME indiansbert -e live-alegre-indiansbert SENTENCE_TRANSFORMERS_HOME /mnt/models/indiansbert-cache -e live-alegre-indiansbert APP alegre -e live-alegre-indiansbert DEPLOY_ENV live -e live-alegre-indiansbert ALEGRE_PORT 8000 --exclusive-secrets `cat live-alegre-indiansbert.env.args`
+    - for NAME in `cat env.live.names`; do echo -n "-s live-alegre-meantokens $NAME /live/alegre/$NAME " >> live-alegre-meantokens.env.args; done
+    - echo -n "-s live-alegre-meantokens GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-alegre-meantokens.env.args
+    - ecs deploy ecs-live  live-alegre-meantokens --diff --image live-alegre-meantokens $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e live-alegre-meantokens MODEL_NAME meantokens -e live-alegre-meantokens SENTENCE_TRANSFORMERS_HOME /mnt/models/meantokens-cache -e live-alegre-meantokens APP alegre -e live-alegre-meantokens DEPLOY_ENV live -e live-alegre-meantokens ALEGRE_PORT 8000 --exclusive-secrets `cat live-alegre-meantokens.env.args`
     - echo "new Image was deployed $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA"
   only:
     - master


### PR DESCRIPTION
As part of the deployment today, the first attempt to deploy the new model tasks will fail because the services don't yet exist. 

I will manually create the services at deploy time, and then the deploy job can be re-run, and succeed.

This change deploys the alegre task updates before attempting to deploy the models.