### PR TITLE
Fix/1338 fix conflict exception

### DIFF
--- a/app/main/controller/audio_transcription_controller.py
+++ b/app/main/controller/audio_transcription_controller.py
@@ -53,10 +53,10 @@ class AudioTranscriptionResource(Resource):
             }
 
         except Exception as e:
-        	print("Oops!", e.__class__, "occurred.")
-        	result = {
-        		'error': e.__class__,
-        	}
+            print("Oops!", repr(e), "occurred.")
+            result = {
+                'error': repr(e),
+            }
 
         return result
 
@@ -100,9 +100,9 @@ class AudioTranscriptionResource(Resource):
             }
 
         except Exception as e:
-            print("Oops!", e.__class__, "occurred.")
+            print("Oops!", repr(e), "occurred.")
             result = {
-                'error': e.__class__,
+                'error': repr(e),
             }
 
         return result

--- a/app/main/controller/audio_transcription_controller.py
+++ b/app/main/controller/audio_transcription_controller.py
@@ -31,26 +31,32 @@ class AudioTranscriptionResource(Resource):
         audioUri = request.get_json().get('url', '')
         result = None
 
-        # try:
-        response = transcribe.start_transcription_job(
-            TranscriptionJobName=jobName,
-            IdentifyLanguage=True,
-            Media={
-                'MediaFileUri': audioUri
-            }
-        )
+        try:
+            response = transcribe.start_transcription_job(
+                TranscriptionJobName=jobName,
+                IdentifyLanguage=True,
+                Media={
+                    'MediaFileUri': audioUri
+                }
+            )
 
-        if response['TranscriptionJob']:
+            if response['TranscriptionJob']:
+                result = {
+                    'job_name': response['TranscriptionJob']['TranscriptionJobName'],
+                    'job_status': response['TranscriptionJob']['TranscriptionJobStatus'],
+                }
+
+        except botocore.exceptions.ClientError as error:
             result = {
-                'job_name': response['TranscriptionJob']['TranscriptionJobName'],
-                'job_status': response['TranscriptionJob']['TranscriptionJobStatus'],
+                'error': error.response['Error']['Code'],
+                'message': error.response['Error']['Message'],
             }
 
-        # except Exception as e:
-        # 	print("Oops!", e.__class__, "occurred.")
-        # 	result = {
-        # 		'error': e.__class__,
-        # 	}
+        except Exception as e:
+        	print("Oops!", e.__class__, "occurred.")
+        	result = {
+        		'error': e.__class__,
+        	}
 
         return result
 

--- a/app/main/controller/audio_transcription_controller.py
+++ b/app/main/controller/audio_transcription_controller.py
@@ -39,6 +39,18 @@ transcribe = boto3.client(
 
 @api.route('/')
 class AudioTranscriptionResource(Resource):
+    def aws_start_transcription(self, jobName, audioUri):
+        return transcribe.start_transcription_job(
+            TranscriptionJobName=jobName,
+            IdentifyLanguage=True,
+            Media={
+                'MediaFileUri': audioUri
+            }
+        )
+
+    def aws_get_transcription(self, jobName):
+        return transcribe.get_transcription_job(TranscriptionJobName=jobName)
+
     @api.response(200, 'Transcription job successfully started.')
     @api.doc('Start transcription job')
     @api.expect(transcription_post, validate=False)
@@ -47,13 +59,7 @@ class AudioTranscriptionResource(Resource):
         audioUri = request.get_json().get('url', '')
         def start_transcription():
             result = None
-            response = transcribe.start_transcription_job(
-                TranscriptionJobName=jobName,
-                IdentifyLanguage=True,
-                Media={
-                    'MediaFileUri': audioUri
-                }
-            )
+            response = self.aws_start_transcription(jobName, audioUri)
             if response['TranscriptionJob']:
                 result = {
                     'job_name': response['TranscriptionJob']['TranscriptionJobName'],
@@ -73,7 +79,7 @@ class AudioTranscriptionResource(Resource):
             jobName = request.json['job_name']
         def get_transcription():
             result = None
-            response = transcribe.get_transcription_job(TranscriptionJobName=jobName)
+            response = self.aws_get_transcription(jobName)
             if response['TranscriptionJob']:
                 job_name = response['TranscriptionJob']['TranscriptionJobName']
                 job_status = response['TranscriptionJob']['TranscriptionJobStatus']

--- a/app/test/test_audio_transcription.py
+++ b/app/test/test_audio_transcription.py
@@ -1,0 +1,51 @@
+import unittest
+import json
+
+from flask import current_app as app
+from unittest.mock import patch
+from app.main import db
+from app.test.base import BaseTestCase
+
+class TestTranscriptionBlueprint(BaseTestCase):
+    def test_post_transcription_job(self):
+        with patch('app.main.controller.audio_transcription_controller.AudioTranscriptionResource.aws_start_transcription', ) as mock_start_transcription:
+            mock_start_transcription.return_value = {
+                'TranscriptionJob': {
+                    'TranscriptionJobName': 'Aloha',
+                    'TranscriptionJobStatus': 'IN_PROGRESS',
+                }
+            }
+            response = self.client.post('/audio/transcription/',
+                data=json.dumps({
+                  'url': 's3://hello-audio-transcription/en-01.wav',
+                  'job_name': 'Aloha',
+                }),
+                content_type='application/json'
+            )
+            result = json.loads(response.data.decode())
+            self.assertEqual('application/json', response.content_type)
+            self.assertEqual(200, response.status_code)
+            self.assertEqual(sorted(result.keys()), ['job_name', 'job_status'])
+
+    def test_get_transcription_job(self):
+        with patch('app.main.controller.audio_transcription_controller.AudioTranscriptionResource.aws_get_transcription', ) as mock_get_transcription:
+            mock_get_transcription.return_value = {
+                'TranscriptionJob': {
+                    'TranscriptionJobName': 'Aloha',
+                    'TranscriptionJobStatus': 'IN_PROGRESS',
+                    'LanguageCode': 'en-EN',
+                }
+            }
+            response = self.client.get('/audio/transcription/',
+                data=json.dumps({
+                  'job_name': 'Aloha',
+                }),
+                content_type='application/json'
+            )
+            result = json.loads(response.data.decode())
+            self.assertEqual('application/json', response.content_type)
+            self.assertEqual(200, response.status_code)
+            self.assertEqual(sorted(result.keys()), ['job_name', 'job_status', 'language_code'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I have wrapped the POST in a try block, so when a conflicting `job_name` is posted, the endpoint will return a formatted error response:
```
{
    "error":"ConflictException",
    "message":"The requested job name already exists. Use a different job name."
}
```
Check-API can either ignore this or instead of POSTing in the first place, try GETting before POSTing.

For the other `KeyError` that has been flagged, I have added a better printing of other generic Exceptions, which should print both the exception class and message, and will better help understanding what causes them. I'm wondering if there's any standard/best exception handling practices I might be missing here. Please advise.