### PR TITLE
Remove the chromaprint build dir once done

### DIFF
--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -35,6 +35,7 @@ RUN rm /usr/lib/x86_64-linux-gnu/libchromaprint.so.1
 RUN ln -s /usr/local/lib/libchromaprint.so.1.5.0 /usr/lib/x86_64-linux-gnu/libchromaprint.so.1.5.0
 RUN ln -s /usr/local/lib/libchromaprint.so.1 /usr/lib/x86_64-linux-gnu/libchromaprint.so.1
 RUN cd chromaprint && make clean
+RUN rm -rf chromaprint
 RUN echo "set enable-bracketed-paste off" >> ~/.inputrc
 COPY requirements.txt ./
 RUN pip install --upgrade pip


### PR DESCRIPTION
This change removes the chromaprint build directory once the build is complete, as the `make clean` target still leaves too much behind.