### PR TITLE
Change Alegre port to 3100 to avoid conflict on Mac Monterey

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 - docker-compose -f docker-compose.yml -f docker-test.yml up -d
 - docker-compose logs -t -f &
 - echo "Waiting for Elasticsearch indexes..." && until curl --silent --fail -I "http://localhost:9200/alegre_similarity_test"; do sleep 1; done
-- until curl --silent --fail -I "http://localhost:5000"; do sleep 1; done
+- until curl --silent --fail -I "http://localhost:3100"; do sleep 1; done
 - echo "Waiting for model servers..." && while [[ ! '2' =~ $(redis-cli -n 1 SCARD 'SharedModel') ]]; do sleep 1; done
 #comment until fix timeout curl: (28) Operation timed out
 # - docker-compose exec alegre bash -c "curl --max-time 600.0 -OL https://raw.githubusercontent.com/meedan/check-api/develop/spec/pacts/check_api-alegre.json"

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,5 @@ wait:
 	until curl --silent -XGET --fail $(ELASTICSEARCH_URL); do printf '.'; sleep 1; done
 
 contract_testing: wait
-	curl -vvv -X POST "http://alegre:5000/image/similarity/" -H "Content-Type: application/json" -d '{"url":"https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg","threshold":0.9,"context":{}}'
-	pact-verifier --provider-base-url=http://alegre:5000 --pact-url=./app/test/pact/check_api-alegre.json
+	curl -vvv -X POST "http://alegre:3100/image/similarity/" -H "Content-Type: application/json" -d '{"url":"https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg","threshold":0.9,"context":{}}'
+	pact-verifier --provider-base-url=http://alegre:3100 --pact-url=./app/test/pact/check_api-alegre.json

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A media analysis service. Part of the [Check platform](https://meedan.com/check)
 - Update your [virtual memory settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html), e.g. by setting `vm.max_map_count=262144` in `/etc/sysctl.conf`
 - `docker-compose build`
 - `docker-compose up --abort-on-container-exit`
-- Open http://localhost:5000 for the Alegre API
+- Open http://localhost:3100 for the Alegre API
 
 The Alegre API Swagger UI unfortunately [does not support sending body payloads to GET methods](https://github.com/swagger-api/swagger-ui/issues/2136). To test those API methods, you can still fill in your arguments, and click "Execute" - Swagger will fail, but show you a `curl` command that you can use in your console.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
   alegre:
     build: .
     ports:
-      - "5000:5000"
+      - "3100:3100"
     volumes:
       - ".:/app"
     depends_on:

--- a/manage.py
+++ b/manage.py
@@ -222,7 +222,7 @@ def init_perl_functions():
 @manager.command
 def run():
   """Runs the API server."""
-  port = os.getenv('ALEGRE_PORT', 5000)
+  port = os.getenv('ALEGRE_PORT', 3100)
   if json_logging._current_framework is None:
     json_logging.init_flask(enable_json=True)
     json_logging.init_request_instrument(app)


### PR DESCRIPTION
Port 5000, which Alegre currently runs on, is now used by AirPlay on
Macs running Monterey. As a result, there is an error that port is in
use when our application tries to use that port in development.

To fix this, I modified the external port to 3100, which it seems
to have been at some point in the past (reflected by Check Readme). For
internal consistency, I went ahead and updated the internal port
to 5000, as well, even though it wasn't really necessary.

Fixes CHECK-2147
Related to https://github.com/meedan/check/pull/69