### PR TITLE
Use community wheel of Tensorflow that works with M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN ln -s /usr/local/lib/libchromaprint.so.1 /usr/lib/x86_64-linux-gnu/libchroma
 RUN echo "set enable-bracketed-paste off" >> ~/.inputrc
 COPY requirements.txt ./
 RUN pip install --upgrade pip
+RUN pip install -U https://tf.novaal.de/btver1/tensorflow-2.3.1-cp37-cp37m-linux_x86_64.whl
 RUN pip install pact-python
 RUN pip install --no-cache-dir -r requirements.txt
 RUN python3 -c 'import nltk; nltk.download("punkt")'


### PR DESCRIPTION
The TensorFlow binary downloaded from a normal TensorFlow 2.3.1 pip install (from requirements)
was crashing when we used the linux/x86_64 emulated arch with M1 macs (which is needed
because TensorFlow does not yet have an arm-supported version).

To solve this, we are using a community wheel of Tensorflow 2.3.1 compiled as we need it.

More on this here: https://github.com/tensorflow/tensorflow/issues/52845

Paired with @ahmednasserswe! We confirmed working on M1 Macs, would appreciate if others could confirm this approach works locally for non-M1 Mac machines (we're hardcoding the TensorFlow version).

CHECK-2147