### PR TITLE
Fixes creating text graphs

### DIFF
--- a/app/main/lib/graph_writer.py
+++ b/app/main/lib/graph_writer.py
@@ -57,12 +57,13 @@ def package_item_for_query(item, graph, data_type):
   elif data_type == "text":
     vector_keys = [k for k in item["_source"].keys() if "vector" in k]
     vector_key = ""
+    model = graph.context.get("model") or "elasticsearch"
     if vector_keys:
       vector_key = vector_keys[0]
     return {
-      "model": graph.context.get("model") or "elasticsearch",
+      "models": [model],
       "threshold": graph.threshold,
-      "text": item.get("_source").get("content"),
+      "content": item.get("_source").get("content"),
       "vector": item.get("_source").get(vector_key),
     }
 


### PR DESCRIPTION
When I was trying to generate text clusters locally, it didn’t fail, but no clusters were returned. It worked well for images. Looks like some changes to text similarity were not reflects in the graph writer. Looks like "model" should now be "models" and "text" should be "content". I'm not sure, so I'll ask Devin to review it.

Fixes CHECK-2212.