### PR TITLE
Use Git Repo Sync action to update GitLab repository for CI/CD.

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -1,0 +1,19 @@
+name: GitLab Mirror
+
+on: 
+  - push
+  - delete
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    name: Git Repo Sync
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: wangchucheng/git-repo-sync@v0.1.0
+      with:
+        target-url: https://gitlab.com/meedan/alegre.git/
+        target-username: sonoransun
+        target-token: ${{ secrets.GITLAB_ACCESS_TOKEN }}


### PR DESCRIPTION
This change incorporates the Git Repo Sync action to update GitLab repository for CI/CD purposes.