### PR TITLE
Fixing PostgreSQL Dockerfile.

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -2,9 +2,14 @@ FROM postgres:11.4
 
 MAINTAINER Alexey Kovrizhkin <lekovr+dopos@gmail.com>
 
-ENV DOCKERFILE_VERSION  190701
+ENV DOCKERFILE_VERSION 190701
 
-RUN apt-get update && apt-get install -y \
+RUN rm -rf /etc/apt/sources.list.d/* && \
+    echo 'deb http://deb.debian.org/debian/ stretch main contrib non-free' > /etc/apt/sources.list && \
+    echo 'deb http://security.debian.org/ stretch/updates main contrib non-free' >> /etc/apt/sources.list && \
+    apt-get update && apt-get install apt-transport-https libcurl3-gnutls -y && \
+    echo 'deb https://apt-archive.postgresql.org/pub/repos/apt stretch-pgdg main' >> /etc/apt/sources.list && \
+    apt-get update && apt-get install -y \
     gawk \
     postgresql-plperl-$PG_MAJOR \
     && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8 \


### PR DESCRIPTION
All CI builds were failing with this error:

```
W: The repository 'http://apt.postgresql.org/pub/repos/apt stretch-pgdg Release' does not have a Release file.
E: Failed to fetch http://apt.postgresql.org/pub/repos/apt/dists/stretch-pgdg/11/binary-amd64/Packages  404  Not Found [IP: 147.75.85.69 80]
E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt-get update && apt-get install -y     gawk     postgresql-plperl-$PG_MAJOR     && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8     && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
Service 'postgres' failed to build : Build failed
```

Here's an announcement: https://www.postgresql.org/message-id/Y2kmqL%2BpCuSZiQBV%40msg.df7cb.de

Fixed by installing the packages from the archive repository.