### PR TITLE
CV2-2608: Raise an exception if language is not supported

### DIFF
--- a/app/main/lib/reindex_analyzers.py
+++ b/app/main/lib/reindex_analyzers.py
@@ -64,5 +64,7 @@ def store_updated_docs(docs_to_transform):
                         fail_count += 1
 
 def run(team_id, language=None):
+    if language!=None and language not in SUPPORTED_LANGUAGES:
+         raise Exception(f"Unsupported language: {language} is not a supported language.")
     docs_to_transform = get_cached_docs_to_transform(team_id, language)
     store_updated_docs(docs_to_transform)


### PR DESCRIPTION
This is to prevent inadverent specification of languages where we do not have a language analyzer