### PR TITLE
[CV2-477] vector number no more

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A media analysis service. Part of the [Check platform](https://meedan.com/check)
 
 ## Development
 
-- Update your [virtual memory settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html), e.g. by setting `vm.max_map_count=262144` in `/etc/sysctl.conf`
+- Update your [virtual memory settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html), e.g. by setting `vm.max_map_count=262144` in `/etc/sysctl.conf`. This can also be done by the Docker UI, adjusting Resource settings to 12GB memory and 128GB of disk.  
+- Ensure that the services needed are uncommented in the `docker-compose.yml` file.  Specifically, to run the default tests the `xlm_r_bert_base_nli_stsb_mean_tokens`, `indian_sbert`, `video` and `audio` definitions are needed.
 - `docker-compose build`
 - `docker-compose up --abort-on-container-exit`
 - Open http://localhost:3100 for the Alegre API
@@ -14,19 +15,20 @@ The Alegre API Swagger UI unfortunately [does not support sending body payloads 
 
 - Open http://localhost:5601 for the Kibana UI
 - Open http://localhost:9200 for the Elasticsearch API
-- `docker-compose exec alegre flask shell` to get inside a Python shell with the loaded app
+- `docker-compose exec alegre flask shell` to get inside a Python shell in docker container with the loaded app
 
 ## Testing
-
+- For the full set of tests to pass, some configuration secrets are required (i.e. Google Translate API keys, etc)
 - `docker-compose -f docker-compose.yml -f docker-test.yml up --abort-on-container-exit`
 - Wait for the logs to settle, then in a different console:
 - `docker-compose exec alegre make test`
 - `docker-compose exec alegre coverage report`
 
 To test individual modules:
-- `docker-compose exec alegre bash`
+- `docker-compose exec alegre bash` (opens a bash shell with appropriate environment in the docker container)
 - `python manage.py test -p test_similarity.py`
 
 ## Troubleshooting
 
 - If you're having trouble starting Elasticsearch on macOS, with the error `container_name exited with code 137`, you will need to adjust your Docker settings, as per https://www.petefreitag.com/item/848.cfm
+- Note that the alegre docker service definitions in the `alegre` repo may not align with the alegre service definitions in the `check` repository, so different variations of the service may be spun up depending on the directory where `docker-compose up` is executed. 

--- a/app/main/controller/bulk_update_similarity_controller.py
+++ b/app/main/controller/bulk_update_similarity_controller.py
@@ -1,10 +1,10 @@
 from flask import request, current_app as app
 from flask_restplus import Resource, Namespace, fields
-from elasticsearch import Elasticsearch
-from elasticsearch import helpers
 from app.main.lib.fields import JsonObject
-from app.main.lib.shared_models.shared_model import SharedModel
+
 from app.main.controller.bulk_similarity_controller import BulkSimilarityResource
+from app.main.controller.bulk_similarity_controller import json_parse_timestamp
+from app.main.lib.text_similarity import get_document_body
 
 api = Namespace('bulk_update_similarity', description='bulk text similarity operations')
 similarity_request = api.model('bulk_update_similarity_request', {
@@ -16,16 +16,8 @@ class BulkUpdateSimilarityResource(Resource):
         bodies = []
         doc_ids = []
         for document in request.json.get("documents", []):
-            es = Elasticsearch(app.config['ELASTICSEARCH_URL'])
-            body = {'model': document['model']}
-            model = SharedModel.get_client(document['model'])
-            vector = model.get_shared_model_response(document['text'])
-            body['vector_'+str(len(vector))] = vector
-            body['vector_'+document['model']] = vector
-            if 'context' in document:
-                body['context'] = document['context']
             doc_ids.append(document.get("doc_id"))
-            bodies.append(body)
+            bodies.append(json_parse_timestamp(get_document_body(similarity.get_body_for_text_document(document))))
         return doc_ids, bodies
         
     @api.response(200, 'text successfully stored in the similarity database.')

--- a/app/main/controller/bulk_update_similarity_controller.py
+++ b/app/main/controller/bulk_update_similarity_controller.py
@@ -5,6 +5,7 @@ from app.main.lib.fields import JsonObject
 from app.main.controller.bulk_similarity_controller import BulkSimilarityResource
 from app.main.controller.bulk_similarity_controller import json_parse_timestamp
 from app.main.lib.text_similarity import get_document_body
+from app.main.lib import similarity
 
 api = Namespace('bulk_update_similarity', description='bulk text similarity operations')
 similarity_request = api.model('bulk_update_similarity_request', {

--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -18,7 +18,6 @@ def get_document_body(body):
     if model_key != 'elasticsearch':
       model = SharedModel.get_client(model_key)
       vector = model.get_shared_model_response(body['content'])
-      body['vector_'+str(len(vector))] = vector
       body['vector_'+model_key] = vector
       body['model'] = model_key
   return body

--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -29,7 +29,6 @@ def add_text(body, doc_id, language=None):
   return document
 
 def search_text(search_params):
-  # TODO: document schema for search params and validate schema?
   results = {"result": []}
   for model_key in search_params.pop("models", []):
     result = search_text_by_model(dict(**search_params, **{'model': model_key}))

--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -30,6 +30,7 @@ def add_text(body, doc_id, language=None):
   return document
 
 def search_text(search_params):
+  # TODO: document schema for search params and validate schema?
   results = {"result": []}
   for model_key in search_params.pop("models", []):
     result = search_text_by_model(dict(**search_params, **{'model': model_key}))
@@ -106,7 +107,7 @@ def get_vector_model_base_conditions(search_params, model_key, threshold):
                   }
               },
               'script': {
-                  'source': "cosineSimilarity(params.query_vector, 'vector_"+str(len(vector))+"') + 1.0", 
+                  'source': "cosineSimilarity(params.query_vector, 'vector_"+str(model_key)+"') + 1.0", 
                   'params': {
                       'query_vector': vector
                   }

--- a/app/test/test_text_similarity.py
+++ b/app/test/test_text_similarity.py
@@ -19,9 +19,9 @@ class TestTextSimilarity(BaseTestCase):
         index=app.config['ELASTICSEARCH_SIMILARITY']
       )
 
-      def test_get_vector_model_base_conditions(self):
+    def test_get_vector_model_base_conditions(self):
         # check that vector number not included in query about to be run
-        query = get_vector_model_base_conditions({'content':'bananna'}, test_model_key, 0.5)
+        query = get_vector_model_base_conditions({'content':'bananna'}, self.test_model_key, 0.5)
         assert query is not None
         # looking for nested query object
         # {'query': {'script_score': {'min_score': 1.5, 'query': {'bool': 
@@ -31,7 +31,8 @@ class TestTextSimilarity(BaseTestCase):
         assert source_str is not None
         # the 768 part of the key should no longer be there
         assert 'vector_768' not in source_str
+        # the appropriate model key vector should be there
+        assert 'vector_'+self.test_model_key in source_str
         
-
 if __name__ == '__main__':
     unittest.main()

--- a/app/test/test_text_similarity.py
+++ b/app/test/test_text_similarity.py
@@ -4,7 +4,7 @@ from elasticsearch import  Elasticsearch
 from flask import current_app as app
 
 from app.test.base import BaseTestCase
-from app.main.lib.text_similarity import get_vector_model_base_conditions
+from app.main.lib.text_similarity import get_vector_model_base_conditions, get_document_body
 
 class TestTextSimilarity(BaseTestCase):
     test_model_key = 'indian-sbert'
@@ -33,6 +33,25 @@ class TestTextSimilarity(BaseTestCase):
         assert 'vector_768' not in source_str
         # the appropriate model key vector should be there
         assert 'vector_'+self.test_model_key in source_str
+
+    def test_get_document_body(self):
+        test_content = {
+                  'text': 'this is a test',
+                  'models': [self.test_model_key],  # e.g. indian-sbert, not elasticsearch
+                  'min_es_score': 0.1,
+                  'content': 'let there be content',
+                }
+        body = get_document_body(body=test_content)
+        # this should list the appropriate model
+        assert body.get('model') is self.test_model_key
+        assert body.get('model_'+self.test_model_key) is not None
+        # this should include the appropriate model vector
+        assert body.get('vector_'+self.test_model_key) is not None
+        # this should NOT have the old vector_768 included
+        assert body.get('vector_768') is None
+
+
+
         
 if __name__ == '__main__':
     unittest.main()

--- a/app/test/test_text_similarity.py
+++ b/app/test/test_text_similarity.py
@@ -1,0 +1,37 @@
+import unittest
+import json
+from elasticsearch import  Elasticsearch
+from flask import current_app as app
+
+from app.test.base import BaseTestCase
+from app.main.lib.text_similarity import get_vector_model_base_conditions
+
+class TestTextSimilarity(BaseTestCase):
+    test_model_key = 'indian-sbert'
+
+    def setUp(self):
+      super().setUp()
+      es = Elasticsearch(app.config['ELASTICSEARCH_URL'])
+      es.indices.delete(index=app.config['ELASTICSEARCH_SIMILARITY'], ignore=[400, 404])
+      es.indices.create(index=app.config['ELASTICSEARCH_SIMILARITY'])
+      es.indices.put_mapping(
+        body=json.load(open('./elasticsearch/alegre_similarity.json')),
+        index=app.config['ELASTICSEARCH_SIMILARITY']
+      )
+
+      def test_get_vector_model_base_conditions(self):
+        # check that vector number not included in query about to be run
+        query = get_vector_model_base_conditions({'content':'bananna'}, test_model_key, 0.5)
+        assert query is not None
+        # looking for nested query object
+        # {'query': {'script_score': {'min_score': 1.5, 'query': {'bool': 
+        #   {'must': [{'match': {'model': {'query': 'indian-sbert'}}}]}}, 
+        #       'script': {'source': "cosineSimilarity(params.query_vector, 'vector_768') ...
+        source_str = query['query']['script_score']['script']['source']
+        assert source_str is not None
+        # the 768 part of the key should no longer be there
+        assert 'vector_768' not in source_str
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     image: docker.elastic.co/kibana/kibana:7.9.2
     ports:
       - "5601:5601"
+    depends_on:
+      - elasticsearch
     environment:
       ELASTICSEARCH_URL: http://elasticsearch:9200
   redis:
@@ -28,6 +30,7 @@ services:
       - "redis:/data"
   postgres:
     build: ./postgres
+    platform: linux/x86_64
     ports:
       - "5432:5432"
     volumes:
@@ -47,64 +50,69 @@ services:
       REPMGR_NODE_NAME: pg-0
       REPMGR_NODE_NETWORK_NAME: pg-0
       REPMGR_PORT_NUMBER: 5432
-  # Uncomment to run models locally
-  # xlm_r_bert_base_nli_stsb_mean_tokens:
-  #   build: .
-  #   command: ["make", "run_model"]
-  #   volumes:
-  #     - ".:/app"
-  #   depends_on:
-  #     - redis
-  #   env_file:
-  #     - .env_file
-  #   environment:
-  #     MODEL_NAME: meantokens
-  # indian_sbert:
-  #   build: .
-  #   command: ["make", "run_model"]
-  #   volumes:
-  #     - ".:/app"
-  #   depends_on:
-  #     - redis
-  #   env_file:
-  #     - .env_file
-  #   environment:
-  #     MODEL_NAME: indiansbert
-  # mdeberta_v3_filipino:
-  #   build: .
-  #   command: ["make", "run_model"]
-  #   volumes:
-  #     - ".:/app"
-  #   depends_on:
-  #     - redis
-  #   env_file:
-  #     - .env_file
-  #   environment:
-  #     MODEL_NAME: mdebertav3filipino
-  # video:
-  #   build: .
-  #   command: ["make", "run_model"]
-  #   volumes:
-  #     - ".:/app"
-  #   depends_on:
-  #     - redis
-  #   env_file:
-  #     - .env_file
-  #   environment:
-  #     MODEL_NAME: video
-  # audio:
-  #   build: .
-  #   command: ["make", "run_model"]
-  #   volumes:
-  #     - ".:/app"
-  #   depends_on:
-  #     - redis
-  #   env_file:
-  #     - .env_file
-  #   environment:
-  #     MODEL_NAME: audio
+  xlm_r_bert_base_nli_stsb_mean_tokens:
+    build: .
+    platform: linux/x86_64
+    command: ["make", "run_model"]
+    volumes:
+      - ".:/app"
+    depends_on:
+      - redis
+    env_file:
+      - .env_file
+    environment:
+      MODEL_NAME: meantokens
+  indian_sbert:
+    build: .
+    platform: linux/x86_64
+    command: ["make", "run_model"]
+    volumes:
+      - ".:/app"
+    depends_on:
+      - redis
+    env_file:
+      - .env_file
+    environment:
+      MODEL_NAME: indiansbert
+  mdeberta_v3_filipino:
+    build: .
+    platform: linux/x86_64
+    command: ["make", "run_model"]
+    volumes:
+      - ".:/app"
+    depends_on:
+      - redis
+    env_file:
+      - .env_file
+    environment:
+      MODEL_NAME: mdebertav3filipino
+  video:
+    build: .
+    platform: linux/x86_64
+    command: ["make", "run_model"]
+    volumes:
+      - ".:/app"
+    depends_on:
+      - redis
+    env_file:
+      - .env_file
+    environment:
+      MODEL_NAME: video
+  audio:
+    build: .
+    platform: linux/x86_64
+    command: ["make", "run_model"]
+    volumes:
+      - ".:/app"
+    depends_on:
+      - redis
+    env_file:
+      - .env_file
+    environment:
+      MODEL_NAME: audio
   queue_worker:
     build: .
+    platform: linux/x86_64
     command: ["make", "run_rq_worker"]
     volumes:
       - ".:/app"
@@ -114,6 +122,7 @@ services:
       - .env_file
   alegre:
     build: .
+    platform: linux/x86_64
     ports:
       - "3100:3100"
     volumes:
@@ -122,8 +131,8 @@ services:
       - postgres
       - kibana
       - redis
-      # - video
-      # - xlm_r_bert_base_nli_stsb_mean_tokens
-      # - indian_sbert
+      - video
+      - xlm_r_bert_base_nli_stsb_mean_tokens
+      - indian_sbert
     env_file:
       - .env_file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,30 +50,30 @@ services:
       REPMGR_NODE_NAME: pg-0
       REPMGR_NODE_NETWORK_NAME: pg-0
       REPMGR_PORT_NUMBER: 5432
-  xlm_r_bert_base_nli_stsb_mean_tokens:
-    build: .
-    platform: linux/x86_64
-    command: ["make", "run_model"]
-    volumes:
-      - ".:/app"
-    depends_on:
-      - redis
-    env_file:
-      - .env_file
-    environment:
-      MODEL_NAME: meantokens
-  indian_sbert:
-    build: .
-    platform: linux/x86_64
-    command: ["make", "run_model"]
-    volumes:
-      - ".:/app"
-    depends_on:
-      - redis
-    env_file:
-      - .env_file
-    environment:
-      MODEL_NAME: indiansbert
+  # xlm_r_bert_base_nli_stsb_mean_tokens:
+  #   build: .
+  #   platform: linux/x86_64
+  #   command: ["make", "run_model"]
+  #   volumes:
+  #     - ".:/app"
+  #   depends_on:
+  #     - redis
+  #   env_file:
+  #     - .env_file
+  #   environment:
+  #     MODEL_NAME: meantokens
+  # indian_sbert:
+  #   build: .
+  #   platform: linux/x86_64
+  #   command: ["make", "run_model"]
+  #   volumes:
+  #     - ".:/app"
+  #   depends_on:
+  #     - redis
+  #   env_file:
+  #     - .env_file
+  #   environment:
+  #     MODEL_NAME: indiansbert
   # mdeberta_v3_filipino:
   #   build: .
   #   platform: linux/x86_64
@@ -86,30 +86,30 @@ services:
   #     - .env_file
   #   environment:
   #     MODEL_NAME: mdebertav3filipino
-  video:
-    build: .
-    platform: linux/x86_64
-    command: ["make", "run_model"]
-    volumes:
-      - ".:/app"
-    depends_on:
-      - redis
-    env_file:
-      - .env_file
-    environment:
-      MODEL_NAME: video
-  audio:
-    build: .
-    platform: linux/x86_64
-    command: ["make", "run_model"]
-    volumes:
-      - ".:/app"
-    depends_on:
-      - redis
-    env_file:
-      - .env_file
-    environment:
-      MODEL_NAME: audio
+  # video:
+  #   build: .
+  #   platform: linux/x86_64
+  #   command: ["make", "run_model"]
+  #   volumes:
+  #     - ".:/app"
+  #   depends_on:
+  #     - redis
+  #   env_file:
+  #     - .env_file
+  #   environment:
+  #     MODEL_NAME: video
+  # audio:
+  #   build: .
+  #   platform: linux/x86_64
+  #   command: ["make", "run_model"]
+  #   volumes:
+  #     - ".:/app"
+  #   depends_on:
+  #     - redis
+  #   env_file:
+  #     - .env_file
+  #   environment:
+  #     MODEL_NAME: audio
   queue_worker:
     build: .
     platform: linux/x86_64
@@ -131,8 +131,8 @@ services:
       - postgres
       - kibana
       - redis
-      - video
-      - xlm_r_bert_base_nli_stsb_mean_tokens
-      - indian_sbert
+      # - video
+      # - xlm_r_bert_base_nli_stsb_mean_tokens
+      # - indian_sbert
     env_file:
       - .env_file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,18 +74,18 @@ services:
       - .env_file
     environment:
       MODEL_NAME: indiansbert
-  mdeberta_v3_filipino:
-    build: .
-    platform: linux/x86_64
-    command: ["make", "run_model"]
-    volumes:
-      - ".:/app"
-    depends_on:
-      - redis
-    env_file:
-      - .env_file
-    environment:
-      MODEL_NAME: mdebertav3filipino
+  # mdeberta_v3_filipino:
+  #   build: .
+  #   platform: linux/x86_64
+  #   command: ["make", "run_model"]
+  #   volumes:
+  #     - ".:/app"
+  #   depends_on:
+  #     - redis
+  #   env_file:
+  #     - .env_file
+  #   environment:
+  #     MODEL_NAME: mdebertav3filipino
   video:
     build: .
     platform: linux/x86_64


### PR DESCRIPTION
https://meedan.atlassian.net/browse/CV2-477

* changed the query syntax to use the model-specific tag for the vector query instead of the older version with the vector length
* added a test to demonstrate change `python manage.py test -p test_text_similarity.py`
* some tweaks to alegre docker container definitions, adding architecture specification to build correctly on M1 macs