### PR TITLE
[CV2-848] auto language index on insert

### DIFF
--- a/app/main/lib/elasticsearch.py
+++ b/app/main/lib/elasticsearch.py
@@ -7,7 +7,8 @@ from elasticsearch.helpers import scan
 from flask import current_app as app
 
 from app.main.lib.language_analyzers import SUPPORTED_LANGUAGES
-from app.main.lib.langid import GoogleLangidProvider
+#from app.main.lib.langid import Cld3LangidProvider as LangidProvider
+from app.main.lib.langid import GoogleLangidProvider as LangidProvider
 
 def get_all_documents_matching_context(context):
   matches, clause_count = generate_matches(context)
@@ -104,18 +105,21 @@ def store_document(body, doc_id, language=None):
     # 'auto' indicates we should try to guess the appropriate language
     if language == 'auto':
         text = body['content']
-        language = GoogleLangidProvider.langid(text)
+        language = LangidProvider.langid(text)['result']['language']
         if language not in SUPPORTED_LANGUAGES:
             app.logger.warning('Detected language {} is not supported'.format(language))
             language = None
 
-    if language is not None and language in SUPPORTED_LANGUAGES:
+    if (language is not None) and (language in SUPPORTED_LANGUAGES):
       # also cache in the language-specific index
       indices.append(app.config['ELASTICSEARCH_SIMILARITY']+"_"+language)
     
     results = []
     for index in indices:
-      results.append(update_or_create_document(body, doc_id, index))
+      index_result = update_or_create_document(body, doc_id, index)
+      results.append(index_result)
+      if index_result['result'] not in ['created', 'updated']:
+          app.logger.warning('Problem adding document to ES index for language {0}: {1}'.format(language, index_result))
     result = results[0]
     success = False
     # Note: when we modify more than one index we are only checking the first result

--- a/app/main/lib/elasticsearch.py
+++ b/app/main/lib/elasticsearch.py
@@ -107,10 +107,10 @@ def store_document(body, doc_id, language=None):
         text = body['content']
         try: 
             language = GoogleLangidProvider.langid(text)
-        except: google.auth.exceptions.RefreshError
+        except google.auth.exceptions.RefreshError as e:
+            # credentials are probably missing but we do not want to crash
             language = None
-            # TODO: log warning
-        
+            app.logger.warning('Error loading Google language parsing {}'.format(e))
         
     if language is not None and language in SUPPORTED_LANGUAGES:
       indices.append(app.config['ELASTICSEARCH_SIMILARITY']+"_"+language)

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -53,7 +53,7 @@ def add_item(item, similarity_type):
     doc_id = item.pop("doc_id", None)
     language = item.pop("language", None)
     response = add_text(item, doc_id, language)
-  app.logger.info(f"[Alegre Similarity] [Item {item}, Similarity type: {similarity_type}] response for delete was {response}")
+  app.logger.info(f"[Alegre Similarity] [Item {item}, Similarity type: {similarity_type}] response for add was {response}")
   return response
 
 def delete_item(item, similarity_type):

--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -3,7 +3,8 @@ from elasticsearch import Elasticsearch
 from app.main.lib.elasticsearch import generate_matches, truncate_query, store_document, delete_document
 from app.main.lib.shared_models.shared_model import SharedModel
 from app.main.lib.language_analyzers import SUPPORTED_LANGUAGES
-from app.main.lib.langid import GoogleLangidProvider
+#from app.main.lib.langid import Cld3LangidProvider as LangidProvider
+from app.main.lib.langid import GoogleLangidProvider as LangidProvider
 ELASTICSEARCH_DEFAULT_LIMIT = 10000
 def delete_text(doc_id, context, quiet):
   return delete_document(doc_id, context, quiet)
@@ -156,7 +157,7 @@ def search_text_by_model(search_params):
         # 'auto' indicates we should try to guess the appropriate language
         if language == 'auto':
             text = search_params.get("content")
-            language = GoogleLangidProvider.langid(text)
+            language = LangidProvider.langid(text)['result']['language']
             if language not in SUPPORTED_LANGUAGES:
                 app.logger.warning('Detected language in query text {} is not explicitly supported for indexing, defaulting to "none"'.format(language))
                 language = None

--- a/app/test/test_similarity.py
+++ b/app/test/test_similarity.py
@@ -440,7 +440,7 @@ class TestSimilarityBlueprint(BaseTestCase):
                     '/text/similarity/',
                     data=json.dumps({
                       'text': example['text'],
-                      #'language': example['language'], 
+                      'language': expected_lang, # <- note correct lang id must be here
                       'threshold': 0.0
                     }),
                     content_type='application/json'

--- a/app/test/test_similarity.py
+++ b/app/test/test_similarity.py
@@ -398,104 +398,6 @@ class TestSimilarityBlueprint(BaseTestCase):
             result = json.loads(delete_response.data.decode())
             self.assertEqual('deleted', result['result'])
 
-    def test_all_analyzers(self):
-        examples = [{ 'text': 'केले को कैसे काटें', 'language': 'hi'}, {'text': 'how to slice a banana', 'language': 'en'}, {'text': 'como rebanar un plátano', 'language': 'es'}, {'text': 'কিভাবে একটি কলা টুকরা করা হয়', 'language': 'bn'}]
-        with self.client:
-            for example in examples:
-                response = self.client.post('/text/similarity/', data=json.dumps(example), content_type='application/json')
-                result = json.loads(response.data.decode())
-                self.assertEqual(True, result['success'])
-                es = Elasticsearch(app.config['ELASTICSEARCH_URL'])
-                es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY']+"_"+example['language'])
-                response = self.client.get(
-                    '/text/similarity/',
-                    data=json.dumps({
-                      'text': example['text'],
-                      'language': example['language'],
-                      'threshold': 0.0
-                    }),
-                    content_type='application/json'
-                )
-                result = json.loads(response.data.decode())
-                self.assertTrue(app.config['ELASTICSEARCH_SIMILARITY']+"_"+example['language'] in [e['_index'] for e in result['result']])
-
-    def test_auto_language_id(self):
-        # language examples as input to language classifier
-        examples = [{'text': 'केले को कैसे काटें', 'language': 'auto'}, # hi
-                    {'text': 'how to slice a banana', 'language': 'auto'}, # en
-                    {'text': 'como rebanar un plátano', 'language': 'auto'}, # es
-                    {'text': 'কিভাবে একটি কলা টুকরা করা হয়', 'language': 'auto'}, # bn
-                    {'text': 'yadda ake yanka ayaba', 'language': 'auto'}]  # ha  (but not supported)
-        
-        # expected language id classification for examples above
-        expected_lang_ids = ['hi','en','es','bn', None]
-        with self.client:
-            for n in range(len(examples)):
-                example = examples[n]
-                expected_lang = expected_lang_ids[n]
-                response = self.client.post('/text/similarity/', data=json.dumps(example), content_type='application/json')
-                result = json.loads(response.data.decode()) # we are feeding in 'auto' expected correct id back
-                self.assertEqual(True, result['success'])
-                es = Elasticsearch(app.config['ELASTICSEARCH_URL'])
-                if expected_lang is None:
-                    es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
-                else:
-                    es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY']+"_"+expected_lang)
-                response = self.client.get(
-                    '/text/similarity/',
-                    data=json.dumps({
-                      'text': example['text'],
-                      'language': expected_lang, # <- note correct lang id must be here
-                      'threshold': 0.0
-                    }),
-                    content_type='application/json'
-                )
-                result = json.loads(response.data.decode())
-                # indirectly checking classification by confirming which index was included in result
-                index_alias = app.config['ELASTICSEARCH_SIMILARITY']
-                if expected_lang is not None:
-                    index_alias = app.config['ELASTICSEARCH_SIMILARITY']+"_"+expected_lang
-                self.assertTrue(index_alias in [e['_index'] for e in result['result']])
-
-    def test_auto_language_query(self):
-      # language examples as input to language classifier
-      examples = [{'text': 'केले को कैसे काटें', 'language': 'hi'}, # hi
-                  {'text': 'how to slice a banana', 'language': 'en'}, # en
-                  {'text': 'como rebanar un plátano', 'language': 'es'}, # es
-                  {'text': 'কিভাবে একটি কলা টুকরা করা হয়', 'language': 'bn'}, # bn
-                  {'text': 'yadda ake yanka ayaba', 'language': 'ha'}]  # ha  (but not supported)
-      
-      # expected language id classification for examples above
-      expected_lang_ids = ['hi','en','es','bn', None]
-      with self.client:
-          for n in range(len(examples)):
-              example = examples[n]
-              expected_lang = expected_lang_ids[n]
-              response = self.client.post('/text/similarity/', data=json.dumps(example), content_type='application/json')
-              result = json.loads(response.data.decode()) # we are feeding in 'auto' expected correct id back
-              self.assertEqual(True, result['success'])
-              es = Elasticsearch(app.config['ELASTICSEARCH_URL'])
-              if expected_lang is None:
-                  es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
-              else:
-                  es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY']+"_"+expected_lang)
-              response = self.client.get(
-                  '/text/similarity/',
-                  data=json.dumps({
-                    'text': example['text'],
-                    'language': 'auto', # <- NOTE auto should guess and find correct id
-                    'threshold': 0.0
-                  }),
-                  content_type='application/json'
-              )
-              result = json.loads(response.data.decode())
-              # indirectly checking classification by confirming which index was included in result
-              index_alias = app.config['ELASTICSEARCH_SIMILARITY']
-              if expected_lang is not None:
-                  index_alias = app.config['ELASTICSEARCH_SIMILARITY']+"_"+expected_lang
-              self.assertTrue(index_alias in [e['_index'] for e in result['result']])
-    
-
     def test_elasticsearch_similarity_hindi(self):
         with self.client:
             for term in [
@@ -603,6 +505,9 @@ class TestSimilarityBlueprint(BaseTestCase):
         self.assertGreater(similarity, 0.7)
 
     def test_wrong_model_key(self):
+        """
+        Tests querying with a model key that doesn't match the one content was index with
+        """
         with self.client:
             term = { 'text': 'how to slice a banana', 'model': TestSimilarityBlueprint.use_model_key, 'context': { 'dbid': 54 }}
             response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')

--- a/app/test/test_similarity.py
+++ b/app/test/test_similarity.py
@@ -456,8 +456,45 @@ class TestSimilarityBlueprint(BaseTestCase):
                 if expected_lang is not None:
                     index_alias = app.config['ELASTICSEARCH_SIMILARITY']+"_"+expected_lang
                 self.assertTrue(index_alias in [e['_index'] for e in result['result']])
-        
+
+    def test_auto_language_query(self):
+      # language examples as input to language classifier
+      examples = [{'text': 'केले को कैसे काटें', 'language': 'hi'}, # hi
+                  {'text': 'how to slice a banana', 'language': 'en'}, # en
+                  {'text': 'como rebanar un plátano', 'language': 'es'}, # es
+                  {'text': 'কিভাবে একটি কলা টুকরা করা হয়', 'language': 'bn'}, # bn
+                  {'text': 'yadda ake yanka ayaba', 'language': 'ha'}]  # ha  (but not supported)
       
+      # expected language id classification for examples above
+      expected_lang_ids = ['hi','en','es','bn', None]
+      with self.client:
+          for n in range(len(examples)):
+              example = examples[n]
+              expected_lang = expected_lang_ids[n]
+              response = self.client.post('/text/similarity/', data=json.dumps(example), content_type='application/json')
+              result = json.loads(response.data.decode()) # we are feeding in 'auto' expected correct id back
+              self.assertEqual(True, result['success'])
+              es = Elasticsearch(app.config['ELASTICSEARCH_URL'])
+              if expected_lang is None:
+                  es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
+              else:
+                  es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY']+"_"+expected_lang)
+              response = self.client.get(
+                  '/text/similarity/',
+                  data=json.dumps({
+                    'text': example['text'],
+                    'language': 'auto', # <- NOTE auto should guess and find correct id
+                    'threshold': 0.0
+                  }),
+                  content_type='application/json'
+              )
+              result = json.loads(response.data.decode())
+              # indirectly checking classification by confirming which index was included in result
+              index_alias = app.config['ELASTICSEARCH_SIMILARITY']
+              if expected_lang is not None:
+                  index_alias = app.config['ELASTICSEARCH_SIMILARITY']+"_"+expected_lang
+              self.assertTrue(index_alias in [e['_index'] for e in result['result']])
+    
 
     def test_elasticsearch_similarity_hindi(self):
         with self.client:

--- a/app/test/test_similarity_lang_analyzers.py
+++ b/app/test/test_similarity_lang_analyzers.py
@@ -1,0 +1,131 @@
+import unittest
+import json
+from elasticsearch import helpers, Elasticsearch, TransportError
+from flask import current_app as app
+import numpy as np
+
+from app.main import db
+from app.test.base import BaseTestCase
+from app.main.lib.shared_models.shared_model import SharedModel
+from unittest.mock import patch
+from  app.main.lib import language_analyzers
+
+class TestSimilarityBlueprint(BaseTestCase):
+    maxDiff = None
+    use_model_key = 'xlm-r-bert-base-nli-stsb-mean-tokens'
+    test_model_key = 'indian-sbert'
+
+    def setUp(self):
+      super().setUp()
+      es = Elasticsearch(app.config['ELASTICSEARCH_URL'])
+      es.indices.delete(index=app.config['ELASTICSEARCH_SIMILARITY'], ignore=[400, 404])
+      es.indices.create(index=app.config['ELASTICSEARCH_SIMILARITY'])
+      es.indices.put_mapping(
+        body=json.load(open('./elasticsearch/alegre_similarity.json')),
+        index=app.config['ELASTICSEARCH_SIMILARITY']
+      )
+      # also make sure all the language specific indices have been dropped and recreated
+      # (this is slow and runs before each test)
+      language_analyzers.init_indices()
+
+
+    def test_all_analyzers(self):
+        examples = [{ 'text': 'केले को कैसे काटें', 'language': 'hi'}, {'text': 'how to slice a banana', 'language': 'en'}, {'text': 'como rebanar un plátano', 'language': 'es'}, {'text': 'কিভাবে একটি কলা টুকরা করা হয়', 'language': 'bn'}]
+        with self.client:
+            for example in examples:
+                response = self.client.post('/text/similarity/', data=json.dumps(example), content_type='application/json')
+                result = json.loads(response.data.decode())
+                self.assertEqual(True, result['success'])
+                es = Elasticsearch(app.config['ELASTICSEARCH_URL'])
+                es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY']+"_"+example['language'])
+                response = self.client.get(
+                    '/text/similarity/',
+                    data=json.dumps({
+                      'text': example['text'],
+                      'language': example['language'],
+                      'threshold': 0.0
+                    }),
+                    content_type='application/json'
+                )
+                result = json.loads(response.data.decode())
+                self.assertTrue(app.config['ELASTICSEARCH_SIMILARITY']+"_"+example['language'] in [e['_index'] for e in result['result']])
+
+    def test_auto_language_id(self):
+        # language examples as input to language classifier
+        examples = [{'text': 'केले को कैसे काटें', 'language': 'auto'}, # hi
+                    {'text': 'how to slice a banana', 'language': 'auto'}, # en
+                    {'text': 'como rebanar un plátano', 'language': 'auto'}, # es
+                    {'text': 'কিভাবে একটি কলা টুকরা করা হয়', 'language': 'auto'}, # bn
+                    {'text': 'yadda ake yanka ayaba', 'language': 'auto'}]  # ha  (but not supported)
+        
+        # expected language id classification for examples above
+        expected_lang_ids = ['hi','en','es','bn', None]
+        with self.client:
+            for n in range(len(examples)):
+                example = examples[n]
+                expected_lang = expected_lang_ids[n]
+                response = self.client.post('/text/similarity/', data=json.dumps(example), content_type='application/json')
+                result = json.loads(response.data.decode()) # we are feeding in 'auto' expected correct id back
+                self.assertEqual(True, result['success'])
+                es = Elasticsearch(app.config['ELASTICSEARCH_URL'])
+                if expected_lang is None:
+                    es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
+                else:
+                    es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY']+"_"+expected_lang)
+                response = self.client.get(
+                    '/text/similarity/',
+                    data=json.dumps({
+                      'text': example['text'],
+                      'language': expected_lang, # <- note correct lang id must be here
+                      'threshold': 0.0
+                    }),
+                    content_type='application/json'
+                )
+                result = json.loads(response.data.decode())
+                # indirectly checking classification by confirming which index was included in result
+                index_alias = app.config['ELASTICSEARCH_SIMILARITY']
+                if expected_lang is not None:
+                    index_alias = app.config['ELASTICSEARCH_SIMILARITY']+"_"+expected_lang
+                self.assertTrue(index_alias in [e['_index'] for e in result['result']])
+
+    def test_auto_language_query(self):
+      # language examples as input to language classifier
+      examples = [{'text': 'केले को कैसे काटें', 'language': 'hi'}, # hi
+                  {'text': 'how to slice a banana', 'language': 'en'}, # en
+                  {'text': 'como rebanar un plátano', 'language': 'es'}, # es
+                  {'text': 'কিভাবে একটি কলা টুকরা করা হয়', 'language': 'bn'}, # bn
+                  {'text': 'yadda ake yanka ayaba', 'language': 'ha'}]  # ha  (but not supported)
+      
+      # expected language id classification for examples above
+      expected_lang_ids = ['hi','en','es','bn', None]
+      with self.client:
+          for n in range(len(examples)):
+              example = examples[n]
+              expected_lang = expected_lang_ids[n]
+              response = self.client.post('/text/similarity/', data=json.dumps(example), content_type='application/json')
+              result = json.loads(response.data.decode()) # we are feeding in 'auto' expected correct id back
+              self.assertEqual(True, result['success'])
+              es = Elasticsearch(app.config['ELASTICSEARCH_URL'])
+              if expected_lang is None:
+                  es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
+              else:
+                  es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY']+"_"+expected_lang)
+              response = self.client.get(
+                  '/text/similarity/',
+                  data=json.dumps({
+                    'text': example['text'],
+                    'language': 'auto', # <- NOTE 'auto' should guess and find correct id
+                    'threshold': 0.0
+                  }),
+                  content_type='application/json'
+              )
+              result = json.loads(response.data.decode())
+              # indirectly checking classification by confirming which index was included in result
+              index_alias = app.config['ELASTICSEARCH_SIMILARITY']
+              if expected_lang is not None:
+                  index_alias = app.config['ELASTICSEARCH_SIMILARITY']+"_"+expected_lang
+              self.assertTrue(index_alias in [e['_index'] for e in result['result']])
+    
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
https://meedan.atlassian.net/browse/CV2-848

Allows passing in 'auto' as the language for text document inserted in Alegre, and will use the google language classifier to try guess the language id and insert in the appropriate index.
* In order to query the document, need to know which index it was inserted into. Also implemented 'auto' for search
* I think we have undefined behavior if we get back a language id we don't support, will default to None for this case
* The new test file resets the language-specific ES indexes before each test to make sure there are not items left over from previous tests
* Although google language classifier introduces an external API dependency, the alternate CLD3 classifier was classifying the English example as Hawaian 