### PR TITLE
Downgrade ElasticSearch module for OpenSearch compatibility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,6 @@ build_qa:
     - docker push "$QA_ECR_API_BASE_URL:latest"
   only:
     - develop
-    - opensearch-compat
 
 deploy_qa:
   image: python:3-alpine
@@ -68,7 +67,6 @@ deploy_qa:
     - echo "new Image was deployed $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA"
   only:
     - develop
-    - opensearch-compat
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
   - build_live
   - deploy_live
 
-build_api_qa:
+build_qa:
   image: docker:latest
   services:
     - docker:dind
@@ -25,6 +25,7 @@ build_api_qa:
     - docker push "$QA_ECR_API_BASE_URL:latest"
   only:
     - develop
+    - opensearch-compat
 
 deploy_qa:
   image: python:3-alpine
@@ -67,6 +68,7 @@ deploy_qa:
     - echo "new Image was deployed $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA"
   only:
     - develop
+    - opensearch-compat
 
 build_live:
   image: docker:latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ cymem==2.0.2
 cytoolz==0.9.0.1
 dill==0.2.8.2
 docutils==0.14
-elasticsearch==7.14.0
+elasticsearch==7.13.4
 fastapi==0.68.0
 feedfinder2==0.0.4
 feedparser==6.0.8


### PR DESCRIPTION
As part of testing the OpenSearch migration we discovered that the 7.14 version of the elasticsearch module is not compatible with opensearch. This is a "feature" rather than technical mismatch, and we can use the elasticsearch module if we downgrade to version 7.13.4.

I am fairly certain this does not introduce any side effects, but I wanted to bring this up to @DGaffney and @computermacgyver for review. Let me know if you have any questions!