### PR TITLE
Support OpenSearch query search on vector fields

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,7 @@ build_qa:
     - docker push "$QA_ECR_API_BASE_URL:latest"
   only:
     - develop
+    - osvector-script-query
 
 deploy_qa:
   image: python:3-alpine
@@ -67,6 +68,7 @@ deploy_qa:
     - echo "new Image was deployed $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA"
   only:
     - develop
+    - osvector-script-query
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,6 @@ build_qa:
     - docker push "$QA_ECR_API_BASE_URL:latest"
   only:
     - develop
-    - osvector-script-query
 
 deploy_qa:
   image: python:3-alpine
@@ -68,7 +67,6 @@ deploy_qa:
     - echo "new Image was deployed $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA"
   only:
     - develop
-    - osvector-script-query
 
 build_live:
   image: docker:latest

--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -105,7 +105,7 @@ def get_vector_model_base_conditions(search_params, model_key, threshold):
                   }
               },
               'script': {
-                  'source': "cosineSimilarity(params.query_vector, doc['vector_"+str(len(vector))+"']) + 1.0", 
+                  'source': "cosineSimilarity(params.query_vector, doc['vector_"+str(model_key)+"']) + 1.0", 
                   'params': {
                       'query_vector': vector
                   }

--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -106,7 +106,7 @@ def get_vector_model_base_conditions(search_params, model_key, threshold):
                   }
               },
               'script': {
-                  'source': "cosineSimilarity(params.query_vector, 'vector_"+str(len(vector))+"') + 1.0", 
+                  'source': "cosineSimilarity(params.query_vector, doc['vector_"+str(len(vector))+"']) + 1.0", 
                   'params': {
                       'query_vector': vector
                   }

--- a/opensearch/alegre_similarity.json
+++ b/opensearch/alegre_similarity.json
@@ -1,0 +1,38 @@
+{ 
+  "mappings": {
+    "properties": {
+      "vector_512": {
+        "type": "knn_vector",
+        "dimension": 512
+      },
+      "vector_768": {
+        "type": "knn_vector",
+        "dimension": 768
+      },
+      "vector_xlm-r-bert-base-nli-stsb-mean-tokens": {
+        "type": "knn_vector",
+        "dimension": 768
+      },
+      "vector_paraphrase-filipino-mpnet-base-v2": {
+        "type": "knn_vector",
+        "dimension": 768
+      },
+      "vector_indian-sbert": {
+        "type": "knn_vector",
+        "dimension": 768
+      },
+      "content": {
+        "type": "text"
+      },
+      "context": {
+        "type": "nested"
+      },
+      "vector": {
+        "type": "double"
+      },
+      "model": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/opensearch/alegre_similarity_knn-aprox-idx.json
+++ b/opensearch/alegre_similarity_knn-aprox-idx.json
@@ -1,0 +1,83 @@
+{ 
+  "mappings": {
+    "properties": {
+      "vector_512": {
+        "type": "knn_vector",
+        "dimension": 512,
+        "method": {
+          "name": "hnsw",
+          "space_type": "cosinesimil",
+          "engine": "nmslib",
+          "parameters": {
+            "ef_construction": 512,
+            "m": 24
+          }
+        }
+      },
+      "vector_768": {
+        "type": "knn_vector",
+        "dimension": 768,
+          "method": {
+          "name": "hnsw",
+          "space_type": "cosinesimil",
+          "engine": "nmslib",
+          "parameters": {
+            "ef_construction": 768,
+            "m": 24
+          }
+        }
+      },
+      "vector_xlm-r-bert-base-nli-stsb-mean-tokens": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "space_type": "cosinesimil",
+          "engine": "nmslib",
+          "parameters": {
+            "ef_construction": 768,
+            "m": 24
+          }
+        }
+      },
+      "vector_paraphrase-filipino-mpnet-base-v2": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "space_type": "cosinesimil",
+          "engine": "nmslib",
+          "parameters": {
+            "ef_construction": 768,
+            "m": 24
+          }
+        }
+      },
+      "vector_indian-sbert": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "space_type": "cosinesimil",
+          "engine": "nmslib",
+          "parameters": {
+            "ef_construction": 768,
+            "m": 24
+          }
+        }
+      },
+      "content": {
+        "type": "text"
+      },
+      "context": {
+        "type": "nested"
+      },
+      "vector": {
+        "type": "double"
+      },
+      "model": {
+        "type": "keyword"
+      }
+    }
+  }
+}


### PR DESCRIPTION
As discussed in DEVOPS-253 there is a slight change in syntax required for script queries against vector fields in OpenSearch. Where as ElasticSearch queries could reference vector fields implicitly in a doc, for OpenSearch `doc[]` must be specified for vector fields.

This change also includes the index definitions for OpenSearch `alegre_similarity` index with and without knn-approximate indexing on vector fields for future use.