### PR TITLE
Remove deprecated vector_512 fields from Alegre similarity index.

### DIFF
--- a/elasticsearch/alegre_similarity.json
+++ b/elasticsearch/alegre_similarity.json
@@ -1,9 +1,5 @@
 {
   "properties": {
-    "vector_512": {
-      "type": "dense_vector",
-      "dims": 512
-    },
     "vector_768": {
       "type": "dense_vector",
       "dims": 768

--- a/opensearch/alegre_similarity.json
+++ b/opensearch/alegre_similarity.json
@@ -1,10 +1,6 @@
 { 
   "mappings": {
     "properties": {
-      "vector_512": {
-        "type": "knn_vector",
-        "dimension": 512
-      },
       "vector_768": {
         "type": "knn_vector",
         "dimension": 768

--- a/opensearch/alegre_similarity_knn-aprox-idx.json
+++ b/opensearch/alegre_similarity_knn-aprox-idx.json
@@ -1,19 +1,6 @@
 { 
   "mappings": {
     "properties": {
-      "vector_512": {
-        "type": "knn_vector",
-        "dimension": 512,
-        "method": {
-          "name": "hnsw",
-          "space_type": "cosinesimil",
-          "engine": "nmslib",
-          "parameters": {
-            "ef_construction": 512,
-            "m": 24
-          }
-        }
-      },
       "vector_768": {
         "type": "knn_vector",
         "dimension": 768,


### PR DESCRIPTION
Per discussion on DEVOPS-253, deprecate the vector_512 fields which are no longer used.