### PR TITLE
Using an archive repository since Debian 9/stretch moved to archive.debian.org

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -4,9 +4,10 @@ MAINTAINER Alexey Kovrizhkin <lekovr+dopos@gmail.com>
 
 ENV DOCKERFILE_VERSION 190701
 
-RUN rm -rf /etc/apt/sources.list.d/* && \
-    echo 'deb http://deb.debian.org/debian/ stretch main contrib non-free' > /etc/apt/sources.list && \
-    echo 'deb http://security.debian.org/ stretch/updates main contrib non-free' >> /etc/apt/sources.list && \
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list && \
+    rm -rf /etc/apt/sources.list.d/* && \
+    echo 'deb http://archive.debian.org/debian/ stretch main contrib non-free' > /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security/ stretch/updates main contrib non-free' >> /etc/apt/sources.list && \
     apt-get update && apt-get install apt-transport-https libcurl3-gnutls -y && \
     echo 'deb https://apt-archive.postgresql.org/pub/repos/apt stretch-pgdg main' >> /etc/apt/sources.list && \
     apt-get update && apt-get install -y \


### PR DESCRIPTION
As per message here: https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html

```
Hi,

the stretch, stretch-debug and stretch-proposed-updates suites have now
also been imported on archive.debian.org. People still interested in
these should update their sources.list.

I plan to remove the suites from the main archive in about a month
(2023-04-23 or later).

The stretch-backports, stretch-backports-sloppy and related debug suites
will likely move soon as well and might be removed from the main archive
around the same time.

Ansgar
```

The fix here is to point the repositories to archive.debian.org.

Fixes CV2-3046.