### PR TITLE
CV2-3111: Mean-tokens was removed from hugging face

### DIFF
--- a/app/main/lib/shared_models/xlm_r_bert_base_nli_stsb_mean_tokens.py
+++ b/app/main/lib/shared_models/xlm_r_bert_base_nli_stsb_mean_tokens.py
@@ -7,7 +7,7 @@ from app.main.lib.similarity_measures import angular_similarity
 
 class XlmRBertBaseNliStsbMeanTokens(SharedModel):
     def load(self):
-        model_name = self.options.get('model_name', 'xlm-r-bert-base-nli-stsb-mean-tokens')
+        model_name = self.options.get('model_name', 'meedan/xlm-r-bert-base-nli-stsb-mean-tokens')
         if self.options.get("model_url"):
             try:
                 self.model = SentenceTransformer(self.options.get("model_url"))

--- a/model_config.json
+++ b/model_config.json
@@ -3,7 +3,7 @@
     "class": "XlmRBertBaseNliStsbMeanTokens",
     "key": "xlm-r-bert-base-nli-stsb-mean-tokens",
     "options": {
-      "model_name": "xlm-r-bert-base-nli-stsb-mean-tokens"
+      "model_name": "meedan/xlm-r-bert-base-nli-stsb-mean-tokens"
     }
   },
   "mdebertav3filipino": {


### PR DESCRIPTION
Now hosting a clone in our huggingface account.

This is all that I think is needed to move from the sentence_transformers repo to our copy of the repo on HuggingFace. Unfortunately I'm not yet able to test because huggingface is also have some general down time. Details on the ticket