### PR TITLE
[CV2-3233] minor tweak to fix intermittent ssl error

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -44,5 +44,7 @@ def create_app(config_name):
         pybrake.LoggingHandler(notifier=app.extensions['pybrake'], level=logging.ERROR)
       )
     logging.basicConfig(level=logging.INFO)
-
+  app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
+      "pool_pre_ping": True,
+  }
   return app


### PR DESCRIPTION
[cv2-3233-fix-intermittent-ssl-fail](https://meedan.atlassian.net/browse/CV2-3233)

```
OperationalError
(psycopg2.OperationalError) SSL connection has been closed unexpectedly
[SQL: SELECT videos.id AS videos_id, videos.doc_id AS videos_doc_id, videos.folder AS videos_folder, videos.filepath AS videos_filepath, videos.url AS videos_url, videos.hash_value AS videos_hash_value, videos.context AS videos_context, videos.created_at AS videos_created_at 
FROM videos 
WHERE videos.url = %(url_1)s]
```

https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic
> The “pre ping” feature will normally emit SQL equivalent to “SELECT 1” each time a connection is checked out from the pool; if an error is raised that is detected as a “disconnect” situation, the connection will be immediately recycled, and all other pooled connections older than the current time are invalidated, so that the next time they are checked out, they will also be recycled before use.

> If the database is still not available when “pre ping” runs, then the initial connect will fail and the error for failure to connect will be propagated normally. In the uncommon situation that the database is available for connections, but is not able to respond to a “ping”, the “pre_ping” will try up to three times before giving up, propagating the database error last received.