### PR TITLE
Increase ES default limit; rewrite get_body_for_text_document

### DIFF
--- a/app/main/controller/bulk_similarity_controller.py
+++ b/app/main/controller/bulk_similarity_controller.py
@@ -39,7 +39,7 @@ class BulkSimilarityResource(Resource):
             bodies.append(
                 json_parse_timestamp(
                     get_document_body(
-                        similarity.get_body_for_text_document(document, mode = 'store')
+                        similarity.get_body_for_text_document(document, mode='store')
                     )
                 )
             )

--- a/app/main/controller/bulk_similarity_controller.py
+++ b/app/main/controller/bulk_similarity_controller.py
@@ -39,7 +39,7 @@ class BulkSimilarityResource(Resource):
             bodies.append(
                 json_parse_timestamp(
                     get_document_body(
-                        similarity.get_body_for_text_document(document)
+                        similarity.get_body_for_text_document(document, mode = 'store')
                     )
                 )
             )

--- a/app/main/controller/bulk_update_similarity_controller.py
+++ b/app/main/controller/bulk_update_similarity_controller.py
@@ -32,7 +32,7 @@ def get_merged_contexts(tmp_doc, existing_doc):
     return copy.deepcopy(merge_contexts(get_document_body(tmp_doc), {"_source": existing_doc})["contexts"])
 
 def update_existing_doc_values(document, existing_doc):
-    cleaned_document = similarity.get_body_for_text_document(document)
+    cleaned_document = similarity.get_body_for_text_document(document, mode = 'store')
     for model_name in cleaned_document.get("models"):
         tmp_doc = copy.deepcopy(cleaned_document)
         tmp_doc["models"] = [model_name]

--- a/app/main/controller/bulk_update_similarity_controller.py
+++ b/app/main/controller/bulk_update_similarity_controller.py
@@ -32,7 +32,7 @@ def get_merged_contexts(tmp_doc, existing_doc):
     return copy.deepcopy(merge_contexts(get_document_body(tmp_doc), {"_source": existing_doc})["contexts"])
 
 def update_existing_doc_values(document, existing_doc):
-    cleaned_document = similarity.get_body_for_text_document(document, mode = 'store')
+    cleaned_document = similarity.get_body_for_text_document(document, mode='store')
     for model_name in cleaned_document.get("models"):
         tmp_doc = copy.deepcopy(cleaned_document)
         tmp_doc["models"] = [model_name]

--- a/app/main/controller/similarity_controller.py
+++ b/app/main/controller/similarity_controller.py
@@ -44,4 +44,4 @@ class SimilarityResource(Resource):
     @api.doc('Make a text similarity query. Note that we currently require GET requests with a JSON body rather than embedded params in the URL. You can achieve this via curl -X GET -H "Content-type: application/json" -H "Accept: application/json" -d \'{"text":"Some Text", "threshold": 0.5, "model": "elasticsearch"}\' "http://[ALEGRE_HOST]/text/similarity"')
     @api.doc(params={'text': 'text to be stored or queried for similarity', 'threshold': 'minimum score to consider, between 0.0 and 1.0 (defaults to 0.9)', 'model': 'similarity model to use: "elasticsearch" (pure Elasticsearch, default) or the key name of an active model'})
     def get(self):
-      return similarity.get_similar_items(similarity.format_text_similarity(request.args or request.json, mode = 'query'), "text")
+      return similarity.get_similar_items(similarity.get_body_for_text_document(request.args or request.json, mode = 'query'), "text")

--- a/app/main/controller/similarity_controller.py
+++ b/app/main/controller/similarity_controller.py
@@ -36,7 +36,7 @@ class SimilarityResource(Resource):
     @api.expect(similarity_request, validate=True)
     def post(self):
         doc_id = request.json.get("doc_id")
-        item = similarity.get_body_for_text_document(request.json)
+        item = similarity.get_body_for_text_document(request.json, mode = 'store')
         item["doc_id"] = doc_id
         return similarity.add_item(item, "text")
 
@@ -44,4 +44,4 @@ class SimilarityResource(Resource):
     @api.doc('Make a text similarity query. Note that we currently require GET requests with a JSON body rather than embedded params in the URL. You can achieve this via curl -X GET -H "Content-type: application/json" -H "Accept: application/json" -d \'{"text":"Some Text", "threshold": 0.5, "model": "elasticsearch"}\' "http://[ALEGRE_HOST]/text/similarity"')
     @api.doc(params={'text': 'text to be stored or queried for similarity', 'threshold': 'minimum score to consider, between 0.0 and 1.0 (defaults to 0.9)', 'model': 'similarity model to use: "elasticsearch" (pure Elasticsearch, default) or the key name of an active model'})
     def get(self):
-      return similarity.get_similar_items(similarity.format_text_similarity_query(request.args or request.json), "text")
+      return similarity.get_similar_items(similarity.format_text_similarity(request.args or request.json, mode = 'query'), "text")

--- a/app/main/controller/similarity_controller.py
+++ b/app/main/controller/similarity_controller.py
@@ -36,7 +36,7 @@ class SimilarityResource(Resource):
     @api.expect(similarity_request, validate=True)
     def post(self):
         doc_id = request.json.get("doc_id")
-        item = similarity.get_body_for_text_document(request.json, mode = 'store')
+        item = similarity.get_body_for_text_document(request.json, mode='store')
         item["doc_id"] = doc_id
         return similarity.add_item(item, "text")
 
@@ -44,4 +44,4 @@ class SimilarityResource(Resource):
     @api.doc('Make a text similarity query. Note that we currently require GET requests with a JSON body rather than embedded params in the URL. You can achieve this via curl -X GET -H "Content-type: application/json" -H "Accept: application/json" -d \'{"text":"Some Text", "threshold": 0.5, "model": "elasticsearch"}\' "http://[ALEGRE_HOST]/text/similarity"')
     @api.doc(params={'text': 'text to be stored or queried for similarity', 'threshold': 'minimum score to consider, between 0.0 and 1.0 (defaults to 0.9)', 'model': 'similarity model to use: "elasticsearch" (pure Elasticsearch, default) or the key name of an active model'})
     def get(self):
-      return similarity.get_similar_items(similarity.get_body_for_text_document(request.args or request.json, mode = 'query'), "text")
+      return similarity.get_similar_items(similarity.get_body_for_text_document(request.args or request.json, mode='query'), "text")

--- a/app/main/controller/similarity_controller.py
+++ b/app/main/controller/similarity_controller.py
@@ -44,4 +44,4 @@ class SimilarityResource(Resource):
     @api.doc('Make a text similarity query. Note that we currently require GET requests with a JSON body rather than embedded params in the URL. You can achieve this via curl -X GET -H "Content-type: application/json" -H "Accept: application/json" -d \'{"text":"Some Text", "threshold": 0.5, "model": "elasticsearch"}\' "http://[ALEGRE_HOST]/text/similarity"')
     @api.doc(params={'text': 'text to be stored or queried for similarity', 'threshold': 'minimum score to consider, between 0.0 and 1.0 (defaults to 0.9)', 'model': 'similarity model to use: "elasticsearch" (pure Elasticsearch, default) or the key name of an active model'})
     def get(self):
-      return similarity.get_similar_items(similarity.get_body_for_text_document(request.args or request.json), "text")
+      return similarity.get_similar_items(similarity.format_text_similarity_query(request.args or request.json), "text")

--- a/app/main/lib/elasticsearch.py
+++ b/app/main/lib/elasticsearch.py
@@ -83,19 +83,23 @@ def update_or_create_document(body, doc_id, index):
       except elasticsearch.exceptions.NotFoundError:
           found_doc = None
       if found_doc:
+          body = {"doc": merge_contexts(body, found_doc)}
+          app.logger.info(f"Sending OpenSearch update: {body}")
           result = es.update(
               id=doc_id,
-              body={"doc": merge_contexts(body, found_doc)},
+              body=body,
               index=index,
               retry_on_conflict=3
           )
       else:
+          app.logger.info(f"Sending OpenSearch store: {body}")
           result = es.index(
               id=doc_id,
               body=body,
               index=index
           )
   else:
+      app.logger.info(f"Sending OpenSearch store without id: {body}")
       result = es.index(
           body=body,
           index=index

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -31,6 +31,10 @@ def get_body_for_text_document(params):
       params['created_at']=datetime.now()
     if 'limit' not in params:
       params['limit']=DEFAULT_SEARCH_LIMIT
+    if 'language' not in params:
+      params['language']=None
+    if 'content' not in params:
+      params['content']=None
 
     app.logger.info(
       f"[Alegre Similarity] get_body_for_text_document:params (end) {params}")

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -14,19 +14,21 @@ def get_body_for_text_document(params):
     models = set()
     if 'model' in params:
         models.add(params['model'])
+        del params['model']
     if 'models' in params:
         models = models|set(params['models'])
     if not models:
         models = ['elasticsearch']
-    params["models"]=list(models)
+    params['models']=list(models)
 
-    # Rename "text" to "content"
-    params["content"]=params.get('text')
-    del params["text"]
+    # Rename "text" to "content" if present
+    if 'text' in params:
+      params['content']=params.get('text')
+      del params["text"]
 
     # Set defaults
     if 'created_at' not in params:
-      params["created_at"]=datetime.now()
+      params['created_at']=datetime.now()
     if 'limit' not in params:
       params['limit']=DEFAULT_SEARCH_LIMIT
 

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -19,22 +19,22 @@ def get_body_for_text_document(params):
         models = models|set(params['models'])
     if not models:
         models = ['elasticsearch']
-    params['models']=list(models)
+    params['models'] = list(models)
 
     # Rename "text" to "content" if present
     if 'text' in params:
-      params['content']=params.get('text')
+      params['content'] = params.get('text')
       del params["text"]
 
     # Set defaults
     if 'created_at' not in params:
-      params['created_at']=datetime.now()
+      params['created_at'] = datetime.now()
     if 'limit' not in params:
-      params['limit']=DEFAULT_SEARCH_LIMIT
+      params['limit'] = DEFAULT_SEARCH_LIMIT
     if 'language' not in params:
-      params['language']=None
+      params['language'] = None
     if 'content' not in params:
-      params['content']=None
+      params['content'] = None
 
     app.logger.info(
       f"[Alegre Similarity] get_body_for_text_document:params (end) {params}")

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -45,7 +45,7 @@ def get_body_for_text_document(params, mode):
     if 'content' not in params:
       params['content'] = None
 
-    if mode=='store':
+    if mode == 'store':
       allow_list = set(['language', 'content', 'created_at', 'models', 'context'])
       keys_to_remove = params.keys() - allow_list
       app.logger.info(

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -11,7 +11,7 @@ def get_body_for_text_document(params, mode):
     """
       This function should only be called when querying or storing a
       document in OpenSearch.
-      @params mode should be "query" (default) or "store"
+      @params mode should be "query" or "store"
       If we are querying for a document, use a permissive approach and keep all params
       with some reformating. If we are storing, we remove unexpected items in
       `params` in order to avoid things being stored in OpenSearch unintentionally

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -17,7 +17,7 @@ def get_body_for_text_document(params, mode):
       `params` in order to avoid things being stored in OpenSearch unintentionally
     """
     app.logger.info(
-    f"[Alegre Similarity] format_text_similarity:params (start) {params}")
+    f"[Alegre Similarity] get_body_for_text_document (mode={mode}):params (start) {params}")
 
     # Combine model and models
     models = set()
@@ -49,12 +49,12 @@ def get_body_for_text_document(params, mode):
       allow_list = set(['language', 'content', 'created_at', 'models', 'context'])
       keys_to_remove = params.keys() - allow_list
       app.logger.info(
-        f"[Alegre Similarity] format_text_similarity:running in `store' mode. Removing {keys_to_remove}")
+        f"[Alegre Similarity] get_body_for_text_document:running in `store' mode. Removing {keys_to_remove}")
       for key in keys_to_remove:
         del params[key]
 
     app.logger.info(
-      f"[Alegre Similarity] format_text_similarity:params (end) {params}")
+      f"[Alegre Similarity] get_body_for_text_document (mode={mode}):params (end) {params}")
     return params
 
 def audio_model():

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -6,9 +6,38 @@ from app.main.lib.image_similarity import add_image, delete_image, search_image
 from app.main.lib.text_similarity import add_text, delete_text, search_text
 DEFAULT_SEARCH_LIMIT = 1000
 logging.basicConfig(level=logging.INFO)
+
 def get_body_for_text_document(params):
+    """
+      This function should only be called when storing a document in OpenSearch.
+      If we are querying for a document, use format_text_similarity_query.
+    """
     app.logger.info(
-    f"[Alegre Similarity] get_body_for_text_document:params (start) {params}")
+    f"[Alegre Similarity] get_body_for_text_document:params {params}")
+    models = set()
+    if 'model' in params:
+        models.add(params['model'])
+    if 'models' in params:
+        models = models|set(params['models'])
+    if not models:
+        models = ['elasticsearch']
+    body = {
+       'language': params.get('language'),
+       'content': params.get('text'),
+       'created_at': params.get('created_at', datetime.now()),
+       'models': list(models),
+       'context': params.get('context')
+       }
+    app.logger.info(
+      f"[Alegre Similarity] get_body_for_text_document:body {body}")
+    return body
+
+def format_text_similarity_query(params):
+    """
+      Reformat params and fill in defaults where need for **querying** OpenSearch
+    """
+    app.logger.info(
+    f"[Alegre Similarity] format_text_similarity_query:params (start) {params}")
 
     # Combine model and models
     models = set()
@@ -37,7 +66,7 @@ def get_body_for_text_document(params):
       params['content'] = None
 
     app.logger.info(
-      f"[Alegre Similarity] get_body_for_text_document:params (end) {params}")
+      f"[Alegre Similarity] format_text_similarity_query:params (end) {params}")
     return params
 
 def audio_model():

--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -203,9 +203,11 @@ def search_text_by_model(search_params):
         else:
             conditions['query']['script_score']['query']['bool']['must'].append(context)
     limit = search_params.get("limit")
+    body = get_body_from_conditions(conditions)
+    app.logger.info(f"Sending OpenSearch query: {body}")
     result = es.search(
         size=limit or ELASTICSEARCH_DEFAULT_LIMIT, #NOTE a default limit of 1000 is given in similarity.py
-        body=get_body_from_conditions(conditions),
+        body=body,
         index=search_indices
     )
     response = strip_vectors(

--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -206,7 +206,7 @@ def search_text_by_model(search_params):
     body = get_body_from_conditions(conditions)
     app.logger.info(f"Sending OpenSearch query: {body}")
     result = es.search(
-        size=limit or ELASTICSEARCH_DEFAULT_LIMIT, #NOTE a default limit of 1000 is given in similarity.py
+        size=limit or ELASTICSEARCH_DEFAULT_LIMIT, #NOTE a default limit is given in similarity.py
         body=body,
         index=search_indices
     )

--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -204,7 +204,7 @@ def search_text_by_model(search_params):
             conditions['query']['script_score']['query']['bool']['must'].append(context)
     limit = search_params.get("limit")
     result = es.search(
-        size=limit or ELASTICSEARCH_DEFAULT_LIMIT,
+        size=limit or ELASTICSEARCH_DEFAULT_LIMIT, #NOTE a default limit of 1000 is given in similarity.py
         body=get_body_from_conditions(conditions),
         index=search_indices
     )

--- a/app/test/test_bulk_update_similarity.py
+++ b/app/test/test_bulk_update_similarity.py
@@ -98,7 +98,7 @@ class TestBulkUpdateSimilarityBlueprint(BaseTestCase):
                     self.assertEqual(result['contexts'], [{'a': 1}])
                     self.assertEqual(result['language'], None)
                     self.assertEqual(result['content'], None)
-                    self.assertEqual(result['limit'], 20)
+                    self.assertEqual(result['limit'], 1000)
                     self.assertEqual(result['context'], {'a': 1})
                     self.assertEqual(result['model_model_1'], 1)
                     self.assertEqual(result['vector_model_1'], [0.0])
@@ -127,7 +127,7 @@ class TestBulkUpdateSimilarityBlueprint(BaseTestCase):
         self.assertEqual(response[1][0]['contexts'], [{'a': 1}])
         self.assertEqual(response[1][0]['language'], None)
         self.assertEqual(response[1][0]['content'], None)
-        self.assertEqual(response[1][0]['limit'], 20)
+        self.assertEqual(response[1][0]['limit'], 1000)
         self.assertEqual(response[1][0]['context'], {'a': 1})
         self.assertEqual(response[1][0]['model_elasticsearch'], 1)
 
@@ -185,7 +185,7 @@ class TestBulkUpdateSimilarityBlueprint(BaseTestCase):
         self.assertEqual(response[1][0]['contexts'], [{'a': 1}])
         self.assertEqual(response[1][0]['language'], None)
         self.assertEqual(response[1][0]['content'], None)
-        self.assertEqual(response[1][0]['limit'], 20)
+        self.assertEqual(response[1][0]['limit'], 1000)
         self.assertEqual(response[1][0]['context'], {'a': 1})
         self.assertEqual(response[1][0]['model_elasticsearch'], 1)
 

--- a/app/test/test_bulk_update_similarity.py
+++ b/app/test/test_bulk_update_similarity.py
@@ -98,7 +98,6 @@ class TestBulkUpdateSimilarityBlueprint(BaseTestCase):
                     self.assertEqual(result['contexts'], [{'a': 1}])
                     self.assertEqual(result['language'], None)
                     self.assertEqual(result['content'], None)
-                    self.assertEqual(result['limit'], 1000)
                     self.assertEqual(result['context'], {'a': 1})
                     self.assertEqual(result['model_model_1'], 1)
                     self.assertEqual(result['vector_model_1'], [0.0])
@@ -127,7 +126,6 @@ class TestBulkUpdateSimilarityBlueprint(BaseTestCase):
         self.assertEqual(response[1][0]['contexts'], [{'a': 1}])
         self.assertEqual(response[1][0]['language'], None)
         self.assertEqual(response[1][0]['content'], None)
-        self.assertEqual(response[1][0]['limit'], 1000)
         self.assertEqual(response[1][0]['context'], {'a': 1})
         self.assertEqual(response[1][0]['model_elasticsearch'], 1)
 
@@ -185,7 +183,6 @@ class TestBulkUpdateSimilarityBlueprint(BaseTestCase):
         self.assertEqual(response[1][0]['contexts'], [{'a': 1}])
         self.assertEqual(response[1][0]['language'], None)
         self.assertEqual(response[1][0]['content'], None)
-        self.assertEqual(response[1][0]['limit'], 1000)
         self.assertEqual(response[1][0]['context'], {'a': 1})
         self.assertEqual(response[1][0]['model_elasticsearch'], 1)
 


### PR DESCRIPTION
Rewrite has get_body_for_text_document keep all params unless they are specifically changed.

`get_body_for_text_document` was written to remove parameters unless they appeared specifically on its allow list. This has led to numerous issues in the past when we introduce new parameters and forget to update this function. It was the root issue behind 
* CV2-2805 : [Alegre] `min_es_search` has no effect
* CV2-3164: per_model_threshold for vector models not using the value set in similarity settings 

In this current ticket (CV2-3253) the issue was the default applied in the function, but I'm taking the opportunity to switch the underlying behavior to avoid potential future issues.