### PR TITLE
CV2-3263 update to bullseye

### DIFF
--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -1,6 +1,6 @@
 # alegre
 
-FROM python:3.7
+FROM python:3.7-bullseye
 MAINTAINER sysops@meedan.com
 
 #


### PR DESCRIPTION
https://meedan.atlassian.net/browse/CV2-3263
> We currently have an issue where alegre (and presto) fail due to an issue with chromaprint’s installation process. This is happening because our ffmpeg version that gets installed on build has updated from version 4 to version 5. In version 5, some of the functions that are used to read files within chromaprint are from ffmpeg’s codebase, and no longer exist as they did in version 4. The fix is to slightly modify a function in chromaprint to update for the latest API. This patch should fix chromaprint installs on Alegre.

> We’ve updated the dockerfile to specify the image as FROM python:3.7-bullseye and that seems to work fine. Of course, I think we use production/Dockerfile in Gitlab, so that’s failing now - building another PR now to solve for that ( ) and then we should be good on Gitlab as well as Travis builds.