### PR TITLE
CV2-3233 try other settings, remove erroneous setting after already initialized

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -44,7 +44,4 @@ def create_app(config_name):
         pybrake.LoggingHandler(notifier=app.extensions['pybrake'], level=logging.ERROR)
       )
     logging.basicConfig(level=logging.INFO)
-  app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
-      "pool_pre_ping": True,
-  }
   return app

--- a/app/main/config.py
+++ b/app/main/config.py
@@ -30,7 +30,8 @@ class Config:
   }
   SQLALCHEMY_TRACK_MODIFICATIONS = False
   SQLALCHEMY_ENGINE_OPTIONS = {
-    'pool_pre_ping': True
+    'pool_pre_ping': True,
+    'pool_recycle': 3600,
   }
   MODEL_NAME = os.getenv('MODEL_NAME')
   MAX_CLAUSE_COUNT = 1000


### PR DESCRIPTION
We're trying to solve a minor, intermittent SSL error that happens on a `Video.all()` query (https://sentry.io/organizations/meedan/issues/4178369233/?project=4504691019677696&query=is%3Aunresolved&referrer=issue-stream&stream_index=0). Our first attempt was to pre-ping the DB to ensure that the connections were live - we're now trying to enforce a max ttl on the connections to an hour, until they're forcibly recycled. I'm fairly sure there are no adverse consequences to this, and there's no connections that last that long in any jobs, so it shouldn't really affect anything. Just trying out more ways to see if we can squash this bug...

Also removing setting the config in two places (specifically, in that second place, we don't actually even get anything - the setting was happening *after* the db is instantiated).