### PR TITLE
CV2-3320 - Do NOT wrap items in `doc`

### DIFF
--- a/app/main/controller/bulk_similarity_controller.py
+++ b/app/main/controller/bulk_similarity_controller.py
@@ -28,7 +28,7 @@ class BulkSimilarityResource(Resource):
             "_op_type": op_type,
             '_index': app.config['ELASTICSEARCH_SIMILARITY'],
             '_id': doc_id,
-            'doc': body
+            '_source': body
         }
 
     def get_bodies_for_request(self):

--- a/app/main/controller/bulk_update_similarity_controller.py
+++ b/app/main/controller/bulk_update_similarity_controller.py
@@ -90,6 +90,6 @@ class BulkUpdateSimilarityResource(Resource):
         all_written = []
         for response_data in response:
             for row in response_data:
-                row["doc"].pop("created_at", None)
+                row["_source"].pop("created_at", None)
                 all_written.append(row)
         return all_written


### PR DESCRIPTION
Alegre /bulk/similarity endpoint makes docs unretrievable because it puts them within a `doc` element rather than at the root of the Elasticsearch/Opensearch item

Verified this bug exists on QA with Opensearch and not just in dev with Elasticsearch. 

See https://meedan.atlassian.net/browse/CV2-3320

