### PR TITLE
added pull request template with prompts

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,7 @@
+## Description
+Please include a very brief high-level description of the problem or feature and technical details or specific code changes on PR
+
+Reference: TICKET-ID (to provide additional context)
+
+## How has this been tested?
+Has it been tested locally? Are there automated tests?


### PR DESCRIPTION
This adds prompts to the PR review process to add some context to PRs:
- for future selves, or people outside org: why was the change made, what was it solving (visible in in git blame)
- for PR reviewers: what kinds of changes were made and how was it tested so we know what to read for when review

No ticket for this, was discussed on a call by devin, scott, skye

Testing:
I just previewed the markdown to make sure it looked ok.  These docs say it is the appropriate file name: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository