### PR TITLE
CV2-3448 add tests and DONE status for failed videos - only error notify on unknown failures

### DIFF
--- a/app/test/test_audio_transcription.py
+++ b/app/test/test_audio_transcription.py
@@ -8,8 +8,20 @@ from app.test.base import BaseTestCase
 from unittest import mock
 from collections import namedtuple
 from botocore.exceptions import ClientError
-
+from app.main.controller.audio_transcription_controller import log_abnormal_failure, transcription_response_package
 class TestTranscriptionBlueprint(BaseTestCase):
+    def test_log_abnormal_failure_returns_true(self):
+        self.assertEqual(True, log_abnormal_failure({"TranscriptionJob": {"FailureReason": "Failed to parse audio file."}}))
+        
+    def test_log_abnormal_failure_returns_false(self):
+        with patch("app.main.lib.error_log.ErrorLog.notify") as mock_notify:
+            mock_notify.return_value = True
+            self.assertEqual(False, log_abnormal_failure({"TranscriptionJob": {"FailureReason": "some other problem"}}))
+
+    
+    def test_transcription_response_package(self):
+        self.assertEqual({'job_name': "foo", 'job_status': "bar", 'language_code': "baz"}, transcription_response_package({"TranscriptionJob": {"TranscriptionJobName": "foo", "TranscriptionJobStatus": "bar", "LanguageCode": "baz"}}))
+
     def test_post_transcription_job(self):
         with patch('app.main.controller.audio_transcription_controller.AudioTranscriptionResource.aws_start_transcription', ) as mock_start_transcription:
             mock_start_transcription.return_value = {


### PR DESCRIPTION
## Description
When we attempt to transcribe videos that are silent, we keep throwing errors on the videos, and we keep retrying them. We should notify that these are not going to work, and not log every attempt to force them to work. Additionally, in CV2-3449 which will immediately follow, we need to add a "DONE" flag for tasks that we will not want to keep retrying. This adds it in anticipation.

Reference: CV2-3348

## How has this been tested?
Hard to replicate this with anything other than tests - I've added tests with identical input to the ones we're seeing in the wild on sentry. 