### PR TITLE
CV2-3467 upgrade alegre to psql 13

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12-buster
+FROM postgres:13-buster
 
 MAINTAINER Alexey Kovrizhkin <lekovr+dopos@gmail.com>
 
@@ -15,7 +15,7 @@ RUN apt-get update && \
     apt-transport-https \
     libcurl3-gnutls \
     gawk \
-    postgresql-plperl-12 \
+    postgresql-plperl-13 \
     && localedef -i ru_RU -c -f UTF-8 -A /usr/share/locale/locale.alias ru_RU.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Description
We're bumping up to Postgres 13 - so we need to upgrade the local image to accommodate. There's nothing in the [postgres 13 changelog](https://www.postgresql.org/docs/13/release-13.html) that raises any immediate concerns, but we need to run all these tests to make sure that we're not breaking something.

Reference: CV2-3467

## How has this been tested?
I've run this locally - a few tests broke but I think they were largely because of minor local docker configuration differences. I'd like to see them pass here, and get the code to a point where it passes here, then we'll run an integration test to confirm we're good to go.
