### PR TITLE
CV2-3679 add new known failure mode

### DIFF
--- a/app/main/controller/audio_transcription_controller.py
+++ b/app/main/controller/audio_transcription_controller.py
@@ -30,7 +30,7 @@ def safely_handle_transcription_job(callback):
 
 def log_abnormal_failure(response):
     normal_failure = False
-    for reason in ["Failed to parse audio file", "must have a speech segment long enough in duration ", "Unsupported audio format"]:
+    for reason in ["Failed to parse audio file", "must have a speech segment long enough in duration ", "Unsupported audio format", "data in your input media file isn't valid"]:
         if reason in response["TranscriptionJob"]["FailureReason"]:
             normal_failure = True
     if not normal_failure:

--- a/app/test/test_audio_transcription.py
+++ b/app/test/test_audio_transcription.py
@@ -10,6 +10,9 @@ from collections import namedtuple
 from botocore.exceptions import ClientError
 from app.main.controller.audio_transcription_controller import log_abnormal_failure, transcription_response_package
 class TestTranscriptionBlueprint(BaseTestCase):
+    def test_log_invalid_returns_true(self):
+        self.assertEqual(True, log_abnormal_failure({"TranscriptionJob": {"FailureReason": "The data in your input media file isn't valid."}}))
+
     def test_log_abnormal_failure_returns_true(self):
         self.assertEqual(True, log_abnormal_failure({"TranscriptionJob": {"FailureReason": "Unsupported audio format AAC."}}))
 


### PR DESCRIPTION
## Description
When we are polling for completed transcriptions, we loudly throw errors when we see reasons where we can't get the transcription and we didn't know about that type of issue, so that we can determine if we need to take some other engineering action. This is yet another case where we don't need to take any action, so we are adding it to our list of known errors.a

Reference: 3679

## How has this been tested?
Not tested locally, but falls into a very known pattern of use
