### PR TITLE
Adding more detailed debugging output 

### DIFF
--- a/app/main/lib/shared_models/shared_model.py
+++ b/app/main/lib/shared_models/shared_model.py
@@ -12,141 +12,159 @@ import re
 
 from flask import current_app as app
 
-Task = namedtuple('Task', 'task_id task_type task_package')
+Task = namedtuple("Task", "task_id task_type task_package")
+
 
 class SharedModel(object):
-  @staticmethod
-  def import_model_class(model_class):
-    class_name = re.sub(r'(?<!^)(?=[A-Z])', '_', model_class).lower()
-    return getattr(importlib.import_module('app.main.lib.shared_models.%s' % class_name), model_class)
-
-  @staticmethod
-  def start_server(model_class, model_key, options={}):
-    class_ = SharedModel.import_model_class(model_class)
-    instance = class_(model_key, options)
-    instance.load()
-    app.logger.info('[%s] Serving model...', model_key)
-    r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
-    r.set('SharedModel:%s' % model_key, json.dumps({
-      'model_class': model_class,
-      'model_key': model_key,
-      'options': options
-    }))
-    r.sadd('SharedModel', model_key)
-    instance.bulk_run()
-
-  @staticmethod
-  def get_servers():
-    r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
-    return [server.decode('utf-8') for server in r.smembers('SharedModel')]
-
-  @staticmethod
-  def get_client(model_key, options={}):
-    r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
-    model_class = json.loads(r.get('SharedModel:%s' % model_key).decode('utf-8'))['model_class']
-    class_ = SharedModel.import_model_class(model_class)
-    return class_(model_key, options)
-
-  def __init__(self, model_key, options={}):
-    self.options = options
-    self.queue_name = model_key
-    self.datastore = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
-
-  def get_task(self, timeout=0):
-    item = self.datastore.blpop(self.queue_name, timeout)
-    if item:
-      task = Task(**json.loads(item[1].decode('utf-8')))
-      app.logger.info('[%s] Picking up task %s', self.queue_name, task.task_id)
-      return task
-
-  def send_response(self, task, response):
-    self.datastore.set(task.task_id, json.dumps({"response": response}))
-
-  def run(self):
-    while True:
-      task = self.get_task()
-      if task:
-        self.send_response(
-          task,
-          self.respond(task.task_package)
+    @staticmethod
+    def import_model_class(model_class):
+        class_name = re.sub(r"(?<!^)(?=[A-Z])", "_", model_class).lower()
+        return getattr(
+            importlib.import_module("app.main.lib.shared_models.%s" % class_name),
+            model_class,
         )
 
-  def get_tasks(self):
-    tasks = []
-    start = datetime.now()
-    while (datetime.now()-start).total_seconds() < 0.1 and len(tasks) < 50:
-      task = self.get_task(1)
-      if task:
-        tasks.append(task)
-    return tasks
+    @staticmethod
+    def start_server(model_class, model_key, options={}):
+        class_ = SharedModel.import_model_class(model_class)
+        instance = class_(model_key, options)
+        instance.load()
+        app.logger.info("[%s] Serving model...", model_key)
+        r = redis.Redis(
+            host=app.config["REDIS_HOST"],
+            port=app.config["REDIS_PORT"],
+            db=app.config["REDIS_DATABASE"],
+        )
+        r.set(
+            "SharedModel:%s" % model_key,
+            json.dumps(
+                {"model_class": model_class, "model_key": model_key, "options": options}
+            ),
+        )
+        r.sadd("SharedModel", model_key)
+        instance.bulk_run()
 
-  def bulk_run(self):
-    while True:
-      tasks = self.get_tasks()
-      responses = ([self.respond(task.task_package) for task in tasks])
-      for i, response in enumerate(responses):
-        self.send_response(
-          tasks[i],
-          response
+    @staticmethod
+    def get_servers():
+        r = redis.Redis(
+            host=app.config["REDIS_HOST"],
+            port=app.config["REDIS_PORT"],
+            db=app.config["REDIS_DATABASE"],
+        )
+        return [server.decode("utf-8") for server in r.smembers("SharedModel")]
+
+    @staticmethod
+    def get_client(model_key, options={}):
+        r = redis.Redis(
+            host=app.config["REDIS_HOST"],
+            port=app.config["REDIS_PORT"],
+            db=app.config["REDIS_DATABASE"],
+        )
+        model_info = r.get("SharedModel:%s" % model_key)
+        assert model_info is not None, f"Unable locate model info for key {model_key}"
+        model_class = json.loads(model_info.decode("utf-8"))["model_class"]
+        class_ = SharedModel.import_model_class(model_class)
+        return class_(model_key, options)
+
+    def __init__(self, model_key, options={}):
+        self.options = options
+        self.queue_name = model_key
+        self.datastore = redis.Redis(
+            host=app.config["REDIS_HOST"],
+            port=app.config["REDIS_PORT"],
+            db=app.config["REDIS_DATABASE"],
         )
 
-  def task_id(self):
-    return str(uuid.uuid4())
+    def get_task(self, timeout=0):
+        item = self.datastore.blpop(self.queue_name, timeout)
+        if item:
+            task = Task(**json.loads(item[1].decode("utf-8")))
+            app.logger.info("[%s] Picking up task %s", self.queue_name, task.task_id)
+            return task
 
-  def task_message(self, analysis_value):
-    return Task(
-      task_id=self.task_id(),
-      task_type=self.queue_name,
-      task_package=analysis_value
-    )
+    def send_response(self, task, response):
+        self.datastore.set(task.task_id, json.dumps({"response": response}))
 
-  def submit_task(self, task):
-    self.push_task(task)
-    return task
+    def run(self):
+        while True:
+            task = self.get_task()
+            if task:
+                self.send_response(task, self.respond(task.task_package))
 
-  def encode_task(self, task):
-    return json.dumps(task._asdict())
+    def get_tasks(self):
+        tasks = []
+        start = datetime.now()
+        while (datetime.now() - start).total_seconds() < 0.1 and len(tasks) < 50:
+            task = self.get_task(1)
+            if task:
+                tasks.append(task)
+        return tasks
 
-  def push_task(self, task):
-    app.logger.info('[%s] Pushing task %s', self.queue_name, task.task_id)
-    return self.datastore.rpush(
-      task.task_type,
-      self.encode_task(task)
-    )
+    def bulk_run(self):
+        while True:
+            tasks = self.get_tasks()
+            responses = [self.respond(task.task_package) for task in tasks]
+            for i, response in enumerate(responses):
+                self.send_response(tasks[i], response)
 
-  def get_task_result(self, task):
-    return self.datastore.get(task.task_id)
+    def task_id(self):
+        return str(uuid.uuid4())
 
-  def delete_task_response(self, task):
-    return self.datastore.delete(task.task_id)
+    def task_message(self, analysis_value):
+        return Task(
+            task_id=self.task_id(),
+            task_type=self.queue_name,
+            task_package=analysis_value,
+        )
 
-  def read_task_response(self, task):
-    result = self.get_task_result(task)
-    if result:
-      return json.loads(
-        result.decode('utf-8')
-      )['response']
+    def submit_task(self, task):
+        self.push_task(task)
+        return task
 
-  def get_task_response(self, task, max_timeout=60):
-    start = datetime.now()
-    while (datetime.now()-start).total_seconds() < max_timeout and self.get_task_result(task) is None:
-      time.sleep(0.001)
-    response = self.read_task_response(task)
-    self.delete_task_response(task)
-    return response
+    def encode_task(self, task):
+        return json.dumps(task._asdict())
 
-  def get_shared_model_response(self, analysis_value):
-    return self.get_task_response(
-      self.submit_task(
-        self.task_message(analysis_value)
-      )
-    )
+    def push_task(self, task):
+        app.logger.info("[%s] Pushing task %s", self.queue_name, task.task_id)
+        return self.datastore.rpush(task.task_type, self.encode_task(task))
 
-  def load(self):
-    raise NotImplementedError("[SharedModel] Subclasses must define a `load` function to load their own model!")
+    def get_task_result(self, task):
+        return self.datastore.get(task.task_id)
 
-  def respond(self, task_package):
-    raise NotImplementedError("[SharedModel] Subclasses must define a `respond` function to process requests!")
+    def delete_task_response(self, task):
+        return self.datastore.delete(task.task_id)
 
-  def similarity(self, vecA, vecB):
-    raise NotImplementedError("[SharedModel] Subclasses must define a `similarity` function to compare values!")
+    def read_task_response(self, task):
+        result = self.get_task_result(task)
+        if result:
+            return json.loads(result.decode("utf-8"))["response"]
+
+    def get_task_response(self, task, max_timeout=60):
+        start = datetime.now()
+        while (
+            datetime.now() - start
+        ).total_seconds() < max_timeout and self.get_task_result(task) is None:
+            time.sleep(0.001)
+        response = self.read_task_response(task)
+        self.delete_task_response(task)
+        return response
+
+    def get_shared_model_response(self, analysis_value):
+        return self.get_task_response(
+            self.submit_task(self.task_message(analysis_value))
+        )
+
+    def load(self):
+        raise NotImplementedError(
+            "[SharedModel] Subclasses must define a `load` function to load their own model!"
+        )
+
+    def respond(self, task_package):
+        raise NotImplementedError(
+            "[SharedModel] Subclasses must define a `respond` function to process requests!"
+        )
+
+    def similarity(self, vecA, vecB):
+        raise NotImplementedError(
+            "[SharedModel] Subclasses must define a `similarity` function to compare values!"
+        )


### PR DESCRIPTION
adding more detailed error debugging output in the response when alegre is unable to find the requested model on lookup (perhaps because skye forgot to start it in the local dev ..)

Note: my editor is applying an opinionated formatter, which has adjusted whitespace to python standards.  The actual change is on line 64, adding:

```
 assert model_info is not None, f"Unable locate model info for key {model_key}"
```

## Description
Please include a very brief high-level description of the problem or feature and technical details or specific code changes on PR

Reference: TICKET-ID (to provide additional context)

## How has this been tested?
Has it been tested locally? 
I confirmed that the alegre system ran locally and gave the desired error response

Are there automated tests?
none added

## Have you considered secure coding practices when writing this code?
This does return additional detail on an error, which can leak info about internal state of the system, however this is an internal service API
