### PR TITLE
Cv2 3827 sync endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,6 +7,7 @@ from .main.controller.about_controller import api as about_ns
 from .main.controller.healthcheck_controller import api as healthcheck_ns
 from .main.controller.langid_controller import api as langid_ns
 from .main.controller.similarity_controller import api as similarity_ns
+from .main.controller.similarity_sync_controller import api as similarity_sync_ns
 from .main.controller.audio_transcription_controller import api as audio_transcription_ns
 from .main.controller.audio_similarity_controller import api as audio_similarity_ns
 from .main.controller.video_similarity_controller import api as video_similarity_ns
@@ -34,6 +35,7 @@ api.add_namespace(healthcheck_ns, path='/healthcheck')
 api.add_namespace(model_ns, path='/model')
 api.add_namespace(langid_ns, path='/text/langid')
 api.add_namespace(similarity_ns, path='/text/similarity')
+api.add_namespace(similarity_sync_ns, path='/similarity/sync')
 api.add_namespace(audio_transcription_ns, path='/audio/transcription')
 api.add_namespace(audio_similarity_ns, path='/audio/similarity')
 api.add_namespace(video_similarity_ns, path='/video/similarity')

--- a/app/main/controller/presto_controller.py
+++ b/app/main/controller/presto_controller.py
@@ -26,8 +26,9 @@ class PrestoResource(Resource):
         data = request.args or request.json
         app.logger.info(f"PrestoResource {action}")
         if action == "add_item":
-            result = similarity.callback_add_item(data, model_type)
-            Webhook.return_webhook(app.config['CHECK_API_HOST'], action, model_type, result)
+            result = similarity.callback_add_item(dict(**data.get("body"), **data.get("response", {})), model_type)
+            if data.get("body", {}).get("requires_callback"):
+                Webhook.return_webhook(app.config['CHECK_API_HOST'], action, model_type, result)
             r = redis.Redis(
                 host=app.config['REDIS_HOST'],
                 port=app.config['REDIS_PORT'],

--- a/app/main/controller/similarity_controller.py
+++ b/app/main/controller/similarity_controller.py
@@ -1,8 +1,6 @@
 from flask import request, current_app as app
-from flask import abort, jsonify
+from flask import abort
 from flask_restplus import Resource, Namespace, fields
-from opensearchpy import OpenSearch
-from app.main.lib.shared_models.shared_model import SharedModel
 
 from app.main.lib.fields import JsonObject
 from app.main.lib import similarity

--- a/app/main/controller/similarity_sync_controller.py
+++ b/app/main/controller/similarity_sync_controller.py
@@ -1,8 +1,6 @@
 from flask import request, current_app as app
-from flask import abort, jsonify
+from flask import abort
 from flask_restplus import Resource, Namespace, fields
-from opensearchpy import OpenSearch
-from app.main.lib.shared_models.shared_model import SharedModel
 
 from app.main.lib.fields import JsonObject
 from app.main.lib import similarity

--- a/app/main/controller/similarity_sync_controller.py
+++ b/app/main/controller/similarity_sync_controller.py
@@ -19,7 +19,7 @@ similarity_sync_request = api.model('similarity_sync_request', {
     'fuzzy': fields.Boolean(required=False, description='whether or not to use fuzzy search on GET queries (only used when model is set to \'elasticsearch\')'),
 })
 @api.route('/<string:similarity_type>')
-class SimilarityResource(Resource):
+class SyncSimilarityResource(Resource):
     @api.response(200, 'text similarity successfully queried.')
     @api.doc('Make a text similarity query. Note that we currently require GET requests with a JSON body rather than embedded params in the URL. You can achieve this via curl -X GET -H "Content-type: application/json" -H "Accept: application/json" -d \'{"text":"Some Text", "threshold": 0.5, "model": "elasticsearch"}\' "http://[ALEGRE_HOST]/text/similarity"')
     @api.doc(params={'text': 'text to be stored or queried for similarity', 'threshold': 'minimum score to consider, between 0.0 and 1.0 (defaults to 0.9)', 'model': 'similarity model to use: "elasticsearch" (pure Elasticsearch, default) or the key name of an active model'})
@@ -28,4 +28,4 @@ class SimilarityResource(Resource):
             package = similarity.get_body_for_text_document(request.json, 'query')
         else:
             package = similarity.get_body_for_media_document(request.json, 'query')
-    return similarity.blocking_get_similar_items(package, similarity_type)
+        return similarity.blocking_get_similar_items(package, similarity_type)

--- a/app/main/controller/similarity_sync_controller.py
+++ b/app/main/controller/similarity_sync_controller.py
@@ -1,5 +1,3 @@
-from flask import request, current_app as app
-from flask import abort
 from flask_restplus import Resource, Namespace, fields
 
 from app.main.lib.fields import JsonObject

--- a/app/main/controller/similarity_sync_controller.py
+++ b/app/main/controller/similarity_sync_controller.py
@@ -1,3 +1,4 @@
+from flask import request
 from flask_restplus import Resource, Namespace, fields
 
 from app.main.lib.fields import JsonObject

--- a/app/main/controller/similarity_sync_controller.py
+++ b/app/main/controller/similarity_sync_controller.py
@@ -1,0 +1,31 @@
+from flask import request, current_app as app
+from flask import abort, jsonify
+from flask_restplus import Resource, Namespace, fields
+from opensearchpy import OpenSearch
+from app.main.lib.shared_models.shared_model import SharedModel
+
+from app.main.lib.fields import JsonObject
+from app.main.lib import similarity
+
+api = Namespace('similarity_sync', description='synchronous similarity operations')
+similarity_sync_request = api.model('similarity_sync_request', {
+    'text': fields.String(required=False, description='text to be stored or queried for similarity'),
+    'url': fields.String(required=False, description='url for item to be stored or queried for similarity'),
+    'doc_id': fields.String(required=False, description='text ID to constrain uniqueness'),
+    'models': fields.List(required=False, description='similarity models to use: ["elasticsearch"] (pure Elasticsearch, default) or the key name of an active model', cls_or_instance=fields.String),
+    'language': fields.String(required=False, description='language code for the analyzer to use during the similarity query (defaults to standard analyzer)'),
+    'threshold': fields.Float(required=False, description='minimum score to consider, between 0.0 and 1.0 (defaults to 0.9)'),
+    'context': JsonObject(required=True, description='context'),
+    'fuzzy': fields.Boolean(required=False, description='whether or not to use fuzzy search on GET queries (only used when model is set to \'elasticsearch\')'),
+})
+@api.route('/<string:similarity_type>')
+class SimilarityResource(Resource):
+    @api.response(200, 'text similarity successfully queried.')
+    @api.doc('Make a text similarity query. Note that we currently require GET requests with a JSON body rather than embedded params in the URL. You can achieve this via curl -X GET -H "Content-type: application/json" -H "Accept: application/json" -d \'{"text":"Some Text", "threshold": 0.5, "model": "elasticsearch"}\' "http://[ALEGRE_HOST]/text/similarity"')
+    @api.doc(params={'text': 'text to be stored or queried for similarity', 'threshold': 'minimum score to consider, between 0.0 and 1.0 (defaults to 0.9)', 'model': 'similarity model to use: "elasticsearch" (pure Elasticsearch, default) or the key name of an active model'})
+    def get(self, similarity_type):
+        if similarity_type == "text":
+            package = similarity.get_body_for_text_document(request.json, 'query')
+        else:
+            package = similarity.get_body_for_media_document(request.json, 'query')
+    return similarity.blocking_get_similar_items(package, similarity_type)

--- a/app/main/lib/serializer.py
+++ b/app/main/lib/serializer.py
@@ -1,0 +1,16 @@
+import json
+import datetime
+
+def safe_serializer(obj):
+    """
+    Serialize datetime objects into string format.
+    
+    Args:
+    - obj (object): The object to be serialized
+    
+    Returns:
+    - str: The string representation of the datetime object
+    """
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    raise TypeError(f"Type {type(obj)} not serializable")

--- a/app/main/lib/serializer.py
+++ b/app/main/lib/serializer.py
@@ -1,4 +1,3 @@
-import json
 import datetime
 
 def safe_serializer(obj):

--- a/app/main/lib/shared_models/audio_model.py
+++ b/app/main/lib/shared_models/audio_model.py
@@ -236,12 +236,12 @@ class AudioModel(SharedModel):
             limit = body.get("raw", {}).get("limit")
             if not body.get("raw"):
                 body["raw"] = {}
-            body["raw"]["hash_value"] = task["response"].get("hash_value")
+            body["hash_value"] = task["response"].get("hash_value")
         else:
             body = task
             threshold = body.get('threshold', 0.0)
             limit = body.get("limit")
-        audio, temporary = self.get_audio(body.get("raw"))
+        audio, temporary = self.get_audio(body)
         context = self.get_context_for_search(body)
         if audio.chromaprint_fingerprint is None:
             callback_url =  Presto.add_item_callback_url(app.config['ALEGRE_HOST'], "audio")

--- a/app/main/lib/shared_models/audio_model.py
+++ b/app/main/lib/shared_models/audio_model.py
@@ -236,7 +236,7 @@ class AudioModel(SharedModel):
             limit = body.get("raw", {}).get("limit")
             if not body.get("raw"):
                 body["raw"] = {}
-            body["hash_value"] = task["response"].get("hash_value")
+            body["hash_value"] = task.get("response", {}).get("hash_value")
         else:
             body = task
             threshold = body.get('threshold', 0.0)

--- a/app/main/lib/shared_models/audio_model.py
+++ b/app/main/lib/shared_models/audio_model.py
@@ -214,7 +214,6 @@ class AudioModel(SharedModel):
         # a redis key that we've received something from presto.
         result = Presto.blocked_response(response, "audio")
         audio.chromaprint_fingerprint = result["response"]["hash_value"]
-        context = self.get_context_for_search(result["body"]["raw"])
         if audio:
             matches = self.search_by_hash_value(audio.chromaprint_fingerprint, task.get("threshold", 0.0), context)
             if temporary:

--- a/app/main/lib/shared_models/audio_model.py
+++ b/app/main/lib/shared_models/audio_model.py
@@ -45,8 +45,10 @@ class AudioModel(SharedModel):
                 saved_audio = existing
         except NoResultFound as e:
             # Otherwise, add new audio, but with context as an array
+            app.logger.debug("Adding Audio object that looks like "+str(audio.__dict__))
             if audio.context and not isinstance(audio.context, list):
                 audio.context = [audio.context]
+                app.logger.debug("Set context to "+str(audio.context))
             db.session.add(audio)
             saved_audio = audio
         except Exception as e:
@@ -90,8 +92,7 @@ class AudioModel(SharedModel):
 
     def add(self, task):
         try:
-            body = task.get("body", {})
-            audio = Audio.from_url(body.get("url"), body.get("raw", {}).get("doc_id"), body.get("raw", {}).get("context", {}), task.get("response", {}).get("hash_value"))
+            audio = Audio(chromaprint_fingerprint=task.get("hash_value"), doc_id=task.get("doc_id"), url=task.get("url"), context=task.get("context", {}))
             try:
               audio = self.save(audio)
             except sqlalchemy.exc.IntegrityError:
@@ -186,10 +187,10 @@ class AudioModel(SharedModel):
         audio = self.get_by_doc_id_or_url(task)
         if audio is None:
             temporary = True
-            if not task.get("raw"):
-                task["raw"] = {"doc_id": str(uuid.uuid4())}
-            self.add(dict(**{"body": task}, **task))
-            audios = db.session.query(Audio).filter(Audio.doc_id==task["raw"].get("doc_id")).all()
+            if not task.get("doc_id"):
+                task["doc_id"] = str(uuid.uuid4())
+            self.add(task)
+            audios = db.session.query(Audio).filter(Audio.doc_id==task.get("doc_id")).all()
             if audios and not audio:
                 audio = audios[0]
         return audio, temporary
@@ -202,6 +203,29 @@ class AudioModel(SharedModel):
             context.pop("content_type", None)
         return context
 
+    def blocking_search(self, task):
+        audio, temporary = self.get_audio(task)
+        context = self.get_context_for_search(task)
+        callback_url =  Presto.add_item_callback_url(app.config['ALEGRE_HOST'], "audio")
+        if task.get("doc_id") is None:
+            task["doc_id"] = str(uuid.uuid4())
+        response = json.loads(Presto.send_request(app.config['PRESTO_HOST'], "audio__Model", callback_url, task, False).text)
+        # Warning: this is a blocking hold to wait until we get a response in 
+        # a redis key that we've received something from presto.
+        result = Presto.blocked_response(response, "audio")
+        audio.chromaprint_fingerprint = result["response"]["hash_value"]
+        context = self.get_context_for_search(result["body"]["raw"])
+        if audio:
+            matches = self.search_by_hash_value(audio.chromaprint_fingerprint, task.get("threshold", 0.0), context)
+            if temporary:
+                self.delete(task)
+            if task.get("limit"):
+                return {"result": matches[:task.get("limit")]}
+            else:
+                return {"result": matches}
+        else:
+            return {"error": "Audio not found for provided task", "task": task}
+
     def search(self, task):
         # here, we have to unpack the task contents to pull out the body,
         # which may be embedded in a body key in the dict if its coming from a presto callback.
@@ -210,17 +234,20 @@ class AudioModel(SharedModel):
             body = task.get("body", {})
             threshold = task.get("raw", {}).get('threshold', 0.0)
             limit = body.get("raw", {}).get("limit")
+            if not body.get("raw"):
+                body["raw"] = {}
+            body["raw"]["hash_value"] = task["response"].get("hash_value")
         else:
             body = task
             threshold = body.get('threshold', 0.0)
             limit = body.get("limit")
-        audio, temporary = self.get_audio(body)
+        audio, temporary = self.get_audio(body.get("raw"))
         context = self.get_context_for_search(body)
         if audio.chromaprint_fingerprint is None:
             callback_url =  Presto.add_item_callback_url(app.config['ALEGRE_HOST'], "audio")
             if task.get("doc_id") is None:
                 task["doc_id"] = str(uuid.uuid4())
-            response = json.loads(Presto.send_request(app.config['PRESTO_HOST'], "audio__Model", callback_url, task).text)
+            response = json.loads(Presto.send_request(app.config['PRESTO_HOST'], "audio__Model", callback_url, task, False).text)
             # Warning: this is a blocking hold to wait until we get a response in 
             # a redis key that we've received something from presto.
             result = Presto.blocked_response(response, "audio")

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -158,12 +158,8 @@ def blocking_get_similar_items(item, similarity_type):
   app.logger.info(f"[Alegre Similarity] [Item {item}, Similarity type: {similarity_type}] searching on item")
   if similarity_type == "audio":
     response = audio_model().blocking_search(model_response_package(item, "search"))
-  elif similarity_type == "video":
-    response = video_model().blocking_search(model_response_package(item, "search"))
-  elif similarity_type == "image":
-    response = blocking_search_image(item)
-  elif similarity_type == "text":
-    response = blocking_search_text(item)
-  app.logger.info(f"[Alegre Similarity] [Item {item}, Similarity type: {similarity_type}] response for search was {response}")
-  return response
+    app.logger.info(f"[Alegre Similarity] [Item {item}, Similarity type: {similarity_type}] response for search was {response}")
+    return response
+  else:
+      raise Exception(f"{similarity_type} modality not implemented for blocking requests!")
 

--- a/app/main/model/audio.py
+++ b/app/main/model/audio.py
@@ -21,14 +21,3 @@ class Audio(db.Model):
   __table_args__ = (
     db.Index('ix_audios_context', context, postgresql_using='gin'),
   )
-
-  @staticmethod
-  def from_url(url, doc_id, context={}, hash_value=[]):
-    """Fetch an audio from a URL and load it
-      :param url: Audio URL
-      :param doc_id: Audio Doc ID
-      :param context: Audio Context
-      :param hash_value: Audio fingerprint
-      :returns: Audio object
-    """
-    return Audio(chromaprint_fingerprint=hash_value, doc_id=doc_id, url=url, context=context)

--- a/app/test/test_audio_similarity.py
+++ b/app/test/test_audio_similarity.py
@@ -141,7 +141,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         result = self.model.add({"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "context": {"has_custom_id": True}})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result', 'success'])
-        self.assertEqual(sorted(result['requested']['body'].keys()), ['context', 'doc_id', 'url'])
+        self.assertEqual(sorted(result['requested'].keys()), ['context', 'doc_id', 'url'])
         self.assertEqual(sorted(result['result'].keys()), ['url'])
 
     def test_search_by_doc_id(self):
@@ -157,8 +157,8 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result["result"][0].keys()), ['chromaprint_fingerprint', 'context', 'doc_id', 'id', 'model', 'score', 'url'])
         self.assertEqual(result["result"][0]['doc_id'], 'Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8')
-        self.assertEqual(result["result"][0]['url'], "http://blah.com")
-        self.assertEqual(result["result"][0]['context'], [{'blah': 1}])
+        self.assertEqual(result["result"][0]['url'], url)
+        self.assertEqual(result["result"][0]['context'], [{'blah': 1, 'has_custom_id': True, 'project_media_id': 12343}])
 
     def test_delete(self):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
@@ -256,7 +256,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         #db.session.add(audio)
         db.session.add(audio2)
         db.session.commit()
-        result = self.model.search({"url": url1, "raw": {"context": {"blah": 2}}, "threshold": 0.9, "response": {"hash_value": [e-1 for e in first_print]}})#.get("body")
+        result = self.model.search({"body": {"url": url1, "raw": {"context": {"blah": 2}}, "threshold": 0.9, "response": {"hash_value": [e-1 for e in first_print]}}})#.get("body")
         second_case = [e for e in result["result"] if e["url"] == url2]
         self.assertGreater(len(second_case),0)
         second_case = second_case[0]
@@ -274,7 +274,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         #db.session.add(audio)
         db.session.add(audio2)
         db.session.commit()
-        result = self.model.search({"url": url1, "raw": {"context": {"blah": 3}}, "response": {"hash_value": [1,2,3]}})
+        result = self.model.search({"body": {"url": url1, "raw": {"context": {"blah": 3}}, "response": {"hash_value": [1,2,3]}}})
         second_case = [e for e in result["result"] if e["url"] == url2][0]
         self.assertIsInstance(second_case, dict)
         self.assertEqual(sorted(second_case.keys()), ['chromaprint_fingerprint', 'context', 'doc_id', 'id', 'model', 'score', 'url'])

--- a/app/test/test_audio_similarity.py
+++ b/app/test/test_audio_similarity.py
@@ -125,7 +125,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
 
     def test_delete_by_doc_id(self):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
-        self.model.add({"body": {"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "context": {"has_custom_id": True}}}).get("body")
+        self.model.add({"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "context": {"has_custom_id": True}}).get("body")
         result = self.model.delete({"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8"})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result'])
@@ -138,7 +138,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
 
     def test_add_by_doc_id(self):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
-        result = self.model.add({"body": {"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "context": {"has_custom_id": True}}})
+        result = self.model.add({"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "context": {"has_custom_id": True}})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result', 'success'])
         self.assertEqual(sorted(result['requested']['body'].keys()), ['context', 'doc_id', 'url'])
@@ -152,8 +152,8 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         db.session.commit()
         with patch('app.main.lib.shared_models.audio_model.AudioModel.get_by_doc_id_or_url', ) as mock_get_by_doc_id_or_url:
             mock_get_by_doc_id_or_url.return_value = audio
-            self.model.add({"body": {"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "context": {"blah": 1, "has_custom_id": True, 'project_media_id': 12343}}}).get("body")
-            result = self.model.search({"body": {"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "raw": {"context": {"blah": 1, "has_custom_id": True, 'project_media_id': 12343}}}})
+            self.model.add({"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "context": {"blah": 1, "has_custom_id": True, 'project_media_id': 12343}}).get("body")
+            result = self.model.search({"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "context": {"blah": 1, "has_custom_id": True, 'project_media_id': 12343}})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result["result"][0].keys()), ['chromaprint_fingerprint', 'context', 'doc_id', 'id', 'model', 'score', 'url'])
         self.assertEqual(result["result"][0]['doc_id'], 'blah')
@@ -162,7 +162,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
 
     def test_delete(self):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
-        self.model.add({"body": {"url": url, "project_media_id": 1, "raw": {"context": {'blah': 1, 'project_media_id': 1}}}})
+        self.model.add({"url": url, "project_media_id": 1, "raw": {"context": {'blah': 1, 'project_media_id': 1}}})
         result = self.model.delete({"url": url, "project_media_id": 1, "context": {'blah': 1, 'project_media_id': 1}})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result'])
@@ -171,7 +171,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
 
     def test_add(self):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
-        result = self.model.add({"body": {"url": url, "project_media_id": 1}})
+        result = self.model.add({"url": url, "project_media_id": 1})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result', 'success'])
         self.assertEqual(sorted(result['requested']['body'].keys()), ['project_media_id', 'url'])
@@ -179,7 +179,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
 
     def test_add_wav(self):
         url = 'file:///app/app/test/data/sample.wav'
-        result = self.model.add({"body": {"url": url, "project_media_id": 1}})
+        result = self.model.add({"url": url, "project_media_id": 1})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result', 'success'])
         self.assertEqual(sorted(result['requested']['body'].keys()), ['project_media_id', 'url'])
@@ -203,7 +203,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
 
     def test_respond_delete(self):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
-        self.model.add({"body": {"url": url, "id": 1, "raw": {"context": {'blah': 1, 'project_media_id': 12342}}}})
+        self.model.add({"url": url, "id": 1, "raw": {"context": {'blah': 1, 'project_media_id': 12342}}})
         result = self.model.respond({"url": url, "project_media_id": 1, "command": "delete", "context": {'blah': 1, 'project_media_id': 12342}})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result'])
@@ -300,7 +300,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         with patch('app.main.lib.shared_models.audio_model.AudioModel.save', ) as mock:
             mock.return_value = False
             url = 'file:///app/app/test/data/test_audio_1.mp3'
-            result = self.model.add({"body": {"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "raw": {"context": {"has_custom_id": True}}}})
+            result = self.model.add({"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "context": {"has_custom_id": True}})
             self.assertIsInstance(result, dict)
             self.assertEqual(False, result['success'])
 
@@ -308,7 +308,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         with patch('app.main.lib.shared_models.audio_model.AudioModel.save', ) as mock:
             url = 'file:///app/app/test/data/test_audio_1.mp3'
             mock.side_effect = urllib.error.HTTPError(url, 420, "HTTP ERROR HAPPENED", None, None)
-            result = self.model.add({"body": {"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "raw": {"context": {"has_custom_id": True}}}})
+            result = self.model.add({"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "context": {"has_custom_id": True}})
             self.assertIsInstance(result, dict)
             self.assertEqual(False, result['success'])
 

--- a/app/test/test_audio_similarity.py
+++ b/app/test/test_audio_similarity.py
@@ -162,7 +162,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
 
     def test_delete(self):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
-        self.model.add({"url": url, "project_media_id": 1, "raw": {"context": {'blah': 1, 'project_media_id': 1}}})
+        self.model.add({"url": url, "context": {"blah": 1, "project_media_id": 1}})
         result = self.model.delete({"url": url, "project_media_id": 1, "context": {'blah': 1, 'project_media_id': 1}})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result'])
@@ -212,10 +212,10 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
 
     def test_respond_add(self):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
-        result = self.model.respond({"body": {"url": url, "project_media_id": 1}, "command": "add"})
+        result = self.model.respond({"url": url, "context": {"blah": 1, "project_media_id": 1}, "command": "add"})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result', 'success'])
-        self.assertEqual(sorted(result['requested'].keys()), ['project_media_id', 'url'])
+        self.assertEqual(sorted(result['requested'].keys()), ['command', 'context', 'url'])
         self.assertEqual(sorted(result['result'].keys()), ['url'])
 
     def test_respond_search(self):
@@ -226,8 +226,8 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         db.session.commit()
         with patch('app.main.lib.shared_models.audio_model.AudioModel.get_by_doc_id_or_url', ) as mock_get_by_doc_id_or_url:
             mock_get_by_doc_id_or_url.return_value = audio
-            self.model.respond({"command": "add", "body": {"threshold": 0.0, "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "url": url, "project_media_id": 1, "context": {"blah": 1, 'project_media_id': 12343}}})
-            result = self.model.respond({"url": url, "project_media_id": 1, "command": "search", "context": {"blah": 1, 'project_media_id': 12343}})
+            self.model.respond({"command": "add", "threshold": 0.0, "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "url": url, "project_media_id": 1, "context": {"blah": 1, 'project_media_id': 12343}})
+            result = self.model.respond({"command": "search", "body": {"url": url, "project_media_id": 1, "context": {"blah": 1, 'project_media_id': 12343}}})
         self.assertEqual(sorted(result["result"][0].keys()), ['chromaprint_fingerprint', 'context', 'doc_id', 'id', 'model', 'score', 'url'])
         self.assertEqual(result["result"][0]['doc_id'], 'blah')
         self.assertEqual(result["result"][0]['url'], 'http://blah.com')

--- a/app/test/test_audio_similarity.py
+++ b/app/test/test_audio_similarity.py
@@ -256,7 +256,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         #db.session.add(audio)
         db.session.add(audio2)
         db.session.commit()
-        result = self.model.search({"body": {"url": url1, "raw": {"context": {"blah": 2}}, "threshold": 0.9, "response": {"hash_value": [e-1 for e in first_print]}}})#.get("body")
+        result = self.model.search({"body": {"url": url1, "raw": {"context": {"blah": 2}}, "threshold": 0.9}, "response": {"hash_value": [e-1 for e in first_print]}})#.get("body")
         second_case = [e for e in result["result"] if e["url"] == url2]
         self.assertGreater(len(second_case),0)
         second_case = second_case[0]
@@ -274,7 +274,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         #db.session.add(audio)
         db.session.add(audio2)
         db.session.commit()
-        result = self.model.search({"body": {"url": url1, "raw": {"context": {"blah": 3}}, "response": {"hash_value": [1,2,3]}}})
+        result = self.model.search({"body": {"url": url1, "raw": {"context": {"blah": 3}}}, "response": {"hash_value": [1,2,3]}})
         second_case = [e for e in result["result"] if e["url"] == url2][0]
         self.assertIsInstance(second_case, dict)
         self.assertEqual(sorted(second_case.keys()), ['chromaprint_fingerprint', 'context', 'doc_id', 'id', 'model', 'score', 'url'])

--- a/app/test/test_audio_similarity.py
+++ b/app/test/test_audio_similarity.py
@@ -256,7 +256,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         #db.session.add(audio)
         db.session.add(audio2)
         db.session.commit()
-        result = self.model.search({"body": {"url": url1, "raw": {"context": {"blah": 2}}, "threshold": 0.9}, "response": {"hash_value": [e-1 for e in first_print]}})#.get("body")
+        result = self.model.search({"body": {"url": url1, "context": {"blah": 2}, "threshold": 0.9}, "response": {"hash_value": [e-1 for e in first_print]}})#.get("body")
         second_case = [e for e in result["result"] if e["url"] == url2]
         self.assertGreater(len(second_case),0)
         second_case = second_case[0]
@@ -274,7 +274,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         #db.session.add(audio)
         db.session.add(audio2)
         db.session.commit()
-        result = self.model.search({"body": {"url": url1, "raw": {"context": {"blah": 3}}}, "response": {"hash_value": [1,2,3]}})
+        result = self.model.search({"body": {"url": url1, "context": {"blah": 3}}, "response": {"hash_value": [1,2,3]}})
         second_case = [e for e in result["result"] if e["url"] == url2][0]
         self.assertIsInstance(second_case, dict)
         self.assertEqual(sorted(second_case.keys()), ['chromaprint_fingerprint', 'context', 'doc_id', 'id', 'model', 'score', 'url'])

--- a/app/test/test_audio_similarity.py
+++ b/app/test/test_audio_similarity.py
@@ -203,7 +203,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
 
     def test_respond_delete(self):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
-        self.model.add({"url": url, "id": 1, "raw": {"context": {'blah': 1, 'project_media_id': 12342}}})
+        self.model.add({"url": url, "id": 1, "context": {'blah': 1, 'project_media_id': 12342}})
         result = self.model.respond({"url": url, "project_media_id": 1, "command": "delete", "context": {'blah': 1, 'project_media_id': 12342}})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result'])

--- a/app/test/test_audio_similarity.py
+++ b/app/test/test_audio_similarity.py
@@ -156,7 +156,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
             result = self.model.search({"url": url, 'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "context": {"blah": 1, "has_custom_id": True, 'project_media_id': 12343}})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result["result"][0].keys()), ['chromaprint_fingerprint', 'context', 'doc_id', 'id', 'model', 'score', 'url'])
-        self.assertEqual(result["result"][0]['doc_id'], 'blah')
+        self.assertEqual(result["result"][0]['doc_id'], 'Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8')
         self.assertEqual(result["result"][0]['url'], "http://blah.com")
         self.assertEqual(result["result"][0]['context'], [{'blah': 1}])
 
@@ -174,7 +174,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         result = self.model.add({"url": url, "project_media_id": 1})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result', 'success'])
-        self.assertEqual(sorted(result['requested']['body'].keys()), ['project_media_id', 'url'])
+        self.assertEqual(sorted(result['requested'].keys()), ['project_media_id', 'url'])
         self.assertEqual(sorted(result['result'].keys()), ['url'])
 
     def test_add_wav(self):
@@ -182,7 +182,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         result = self.model.add({"url": url, "project_media_id": 1})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result', 'success'])
-        self.assertEqual(sorted(result['requested']['body'].keys()), ['project_media_id', 'url'])
+        self.assertEqual(sorted(result['requested'].keys()), ['project_media_id', 'url'])
         self.assertEqual(sorted(result['result'].keys()), ['url'])
 
     def test_search(self):
@@ -193,8 +193,8 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         db.session.commit()
         with patch('app.main.lib.shared_models.audio_model.AudioModel.get_by_doc_id_or_url', ) as mock_get_by_doc_id_or_url:
             mock_get_by_doc_id_or_url.return_value = audio
-            self.model.add({"body": {"doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "url": url, "project_media_id": 1, "raw": {"context": {"blah": 1, 'project_media_id': 12343}}}}).get("body")
-            result = self.model.search({"body": {"url": url, "project_media_id": 1, "raw": {"context": {"blah": 1, 'project_media_id': 12343}}}})
+            self.model.add({"doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "url": url, "project_media_id": 1, "context": {"blah": 1, 'project_media_id': 12343}}).get("body")
+            result = self.model.search({"url": url, "project_media_id": 1, "context": {"blah": 1, 'project_media_id': 12343}})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result["result"][0].keys()), ['chromaprint_fingerprint', 'context', 'doc_id', 'id', 'model', 'score', 'url'])
         self.assertEqual(result["result"][0]['doc_id'], 'blah')
@@ -215,7 +215,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         result = self.model.respond({"body": {"url": url, "project_media_id": 1}, "command": "add"})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result', 'success'])
-        self.assertEqual(sorted(result['requested']["body"].keys()), ['project_media_id', 'url'])
+        self.assertEqual(sorted(result['requested'].keys()), ['project_media_id', 'url'])
         self.assertEqual(sorted(result['result'].keys()), ['url'])
 
     def test_respond_search(self):

--- a/app/test/test_sync_similarity.py
+++ b/app/test/test_sync_similarity.py
@@ -9,6 +9,7 @@ from app.test.base import BaseTestCase
 from app.main.lib.shared_models.shared_model import SharedModel
 from unittest.mock import patch
 from app.main.model.audio import Audio
+from app.main.lib.shared_models.audio_model import AudioModel
 class TestSimilarityBlueprint(BaseTestCase):
     def setUp(self):
         super().setUp()

--- a/app/test/test_sync_similarity.py
+++ b/app/test/test_sync_similarity.py
@@ -2,6 +2,7 @@ import unittest
 import json
 from opensearchpy import helpers, OpenSearch, TransportError
 from flask import current_app as app
+from unittest.mock import Mock, patch
 import numpy as np
 import redis
 
@@ -15,9 +16,6 @@ class TestSimilarityBlueprint(BaseTestCase):
     def setUp(self):
         super().setUp()
         first_print = [-248655731, -231870068, -230690420, -482429284, -478234963, -503476625, -520316369, -521361138, 1634511886, 1647109134, 1647046702, 1646940206, 1646924078, -500563482, -496367961, -471202139, -474282347, -476481849, -510101945, -510069497, -526854905, -237050874, -251730922, -251792089, -503463131, -513949140, -513949140, -1587752392, -1250138600, -180474360, -181522936, -194113975, -261353745, -253227346, -189264210, -188938850, -251825010, -251861834, -797121369, 1366287511, 1898902657, 1932452993, 1932452993, 1936651425, 1928253859, -491814237, -487750941, -496401919, -500657663, -500657643, -483876315, -517414355, -534219217, -529853138, -521597906, -524744474, -459335514, -255973226, -255973242, 1908283526, 1925055878, 1929249159, 1392390532, 1383981188, 1378656532, 1915527460, 1915527212, 1915528248, 1903135752, 1885837336, 1894160408, -253321943, -253326037, -262747077, -263193126, -262311942, -159482198, -151365974, -152489301, -152554837, -228052277, -232251189, -231202597, -243569493, -253069157, -257238902, -257242230, -521302374, -529751382, -517430614, -482831830, -483884501, -479492807, -534139591, -534190021, -534124501, -513115153, -479590737, -487980369, -486931793, -487062593, -488087363, -513253323, -529931243, -529865723, -521475067, -521475065, -252982986, -253179866, -260519706, -514274074, -472199258, -493164874, -1564809486, -1561472269, -1569918447, -1574116603, -1574113276, -1557204988, -483728380, -517313481, -528802706, -520549138, -1600584530, -1600453442, -1583800134, -1281875782, -1292339717, -1293328695, -1292907831, -1292969380, -1276199332, -504392116, -533941748, -533945844, -517414116, -517410760, -483794904, -496311256, -496351175, -487962599, -470136709, -1577427462, -1598339078, -1600568581, -1600634279, -1330097415, -1325833495, -1317312771, -1275466019, -1293353515, -1297496649, -1293171465, -1301552649, -1305742569, -1557473769, -1607807481, -1603604985, -1595314665, -1595378138, -1603522266, -1603522330, -1606676314, -1606479681, -262794049, -205121403, -225572412, 1921977028, 1921870556, -225678721, -224598210, -226713298, -231886802, -231829186, -248598194, -265641530, -265582649, -265579009, -265554513, -534022993, -521585489, -525845329, -525849169, -257413713, -207016049, -219666481, -228034567, -232229591, -232196807, -232008440, -244654327, -253043191, -253041137, -1268125170, -1272393170, -1272425938, -1271376338, -1267184018, -1531426306, -1514481442, -1497699122, -1497636658, -1493655458, -1502040008, -1503018952, -1506029256, -1489472728, -1525145048, -1541863896, -1542898072, -1538704408, -456451591, -459404918, -459388790, -172701558, -139158390, -156983158, -152723318, -161046278, -164192018, -164175634]
-        audio = Audio(chromaprint_fingerprint=first_print, doc_id="blah", url="http://blah.com", context=[{"blah": 1}])
-        db.session.add(audio)
-        db.session.commit()
         self.model = AudioModel('audio')
 
     def tearDown(self): # done in our pytest fixture after yield
@@ -28,7 +26,8 @@ class TestSimilarityBlueprint(BaseTestCase):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
         with patch('requests.post') as mock_post_request:
             r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
-            r.set(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", json.dumps({"response": {"hash_value": [1,2,3]}}))
+            r.delete(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d")
+            r.lpush(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", json.dumps({"response": {"hash_value": [1,2,3]}}))
             mock_response = Mock()
             mock_response.text = json.dumps({
                 'message': 'Message pushed successfully',
@@ -45,7 +44,7 @@ class TestSimilarityBlueprint(BaseTestCase):
                 }
             })
             mock_post_request.return_value = mock_response
-            response = self.client.post('/audio/similarity/', data=json.dumps({
+            response = self.client.get('/similarity/sync/audio', data=json.dumps({
                 'url': url,
                 'doc_id': "1c63abe0-aeb4-4bac-8925-948b69c32d0d",
                 'context': {
@@ -53,13 +52,17 @@ class TestSimilarityBlueprint(BaseTestCase):
                 }
             }), content_type='application/json')
         result = json.loads(response.data.decode())
-        self.assertEqual(result['message'], "Message pushed successfully")
+        self.assertEqual(sorted(result["result"][0].keys()), ['chromaprint_fingerprint', 'context', 'doc_id', 'id', 'model', 'score', 'url'])
+        self.assertEqual(result["result"][0]['doc_id'], '1c63abe0-aeb4-4bac-8925-948b69c32d0d')
+        self.assertEqual(result["result"][0]['url'], 'file:///app/app/test/data/test_audio_1.mp3')
+        self.assertEqual(result["result"][0]['context'], [{'team_id': 1}])
 
     def test_audio_basic_http_responses(self):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
         with patch('requests.post') as mock_post_request:
             r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
-            r.set(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", json.dumps({"response": {"hash_value": [1,2,3]}}))
+            r.delete(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d")
+            r.lpush(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", json.dumps({"response": {"hash_value": [1,2,3]}}))
             mock_response = Mock()
             mock_response.text = json.dumps({
                 'message': 'Message pushed successfully',
@@ -76,7 +79,7 @@ class TestSimilarityBlueprint(BaseTestCase):
                 }
             })
             mock_post_request.return_value = mock_response
-            response = self.client.post('/audio/similarity/', data=json.dumps({
+            response = self.client.get('/similarity/sync/audio', data=json.dumps({
                 'url': url,
                 'project_media_id': 1,
                 'context': {
@@ -84,7 +87,9 @@ class TestSimilarityBlueprint(BaseTestCase):
                 }
             }), content_type='application/json')
         result = json.loads(response.data.decode())
-        self.assertEqual(result['message'], "Message pushed successfully")
+        self.assertEqual(sorted(result["result"][0].keys()), ['chromaprint_fingerprint', 'context', 'doc_id', 'id', 'model', 'score', 'url'])
+        self.assertEqual(result["result"][0]['url'], 'file:///app/app/test/data/test_audio_1.mp3')
+        self.assertEqual(result["result"][0]['context'], [{'team_id': 1}])
 
 if __name__ == '__main__':
     unittest.main()

--- a/app/test/test_sync_similarity.py
+++ b/app/test/test_sync_similarity.py
@@ -1,0 +1,88 @@
+import unittest
+import json
+from opensearchpy import helpers, OpenSearch, TransportError
+from flask import current_app as app
+import numpy as np
+
+from app.main import db
+from app.test.base import BaseTestCase
+from app.main.lib.shared_models.shared_model import SharedModel
+from unittest.mock import patch
+
+class TestSimilarityBlueprint(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        first_print = [-248655731, -231870068, -230690420, -482429284, -478234963, -503476625, -520316369, -521361138, 1634511886, 1647109134, 1647046702, 1646940206, 1646924078, -500563482, -496367961, -471202139, -474282347, -476481849, -510101945, -510069497, -526854905, -237050874, -251730922, -251792089, -503463131, -513949140, -513949140, -1587752392, -1250138600, -180474360, -181522936, -194113975, -261353745, -253227346, -189264210, -188938850, -251825010, -251861834, -797121369, 1366287511, 1898902657, 1932452993, 1932452993, 1936651425, 1928253859, -491814237, -487750941, -496401919, -500657663, -500657643, -483876315, -517414355, -534219217, -529853138, -521597906, -524744474, -459335514, -255973226, -255973242, 1908283526, 1925055878, 1929249159, 1392390532, 1383981188, 1378656532, 1915527460, 1915527212, 1915528248, 1903135752, 1885837336, 1894160408, -253321943, -253326037, -262747077, -263193126, -262311942, -159482198, -151365974, -152489301, -152554837, -228052277, -232251189, -231202597, -243569493, -253069157, -257238902, -257242230, -521302374, -529751382, -517430614, -482831830, -483884501, -479492807, -534139591, -534190021, -534124501, -513115153, -479590737, -487980369, -486931793, -487062593, -488087363, -513253323, -529931243, -529865723, -521475067, -521475065, -252982986, -253179866, -260519706, -514274074, -472199258, -493164874, -1564809486, -1561472269, -1569918447, -1574116603, -1574113276, -1557204988, -483728380, -517313481, -528802706, -520549138, -1600584530, -1600453442, -1583800134, -1281875782, -1292339717, -1293328695, -1292907831, -1292969380, -1276199332, -504392116, -533941748, -533945844, -517414116, -517410760, -483794904, -496311256, -496351175, -487962599, -470136709, -1577427462, -1598339078, -1600568581, -1600634279, -1330097415, -1325833495, -1317312771, -1275466019, -1293353515, -1297496649, -1293171465, -1301552649, -1305742569, -1557473769, -1607807481, -1603604985, -1595314665, -1595378138, -1603522266, -1603522330, -1606676314, -1606479681, -262794049, -205121403, -225572412, 1921977028, 1921870556, -225678721, -224598210, -226713298, -231886802, -231829186, -248598194, -265641530, -265582649, -265579009, -265554513, -534022993, -521585489, -525845329, -525849169, -257413713, -207016049, -219666481, -228034567, -232229591, -232196807, -232008440, -244654327, -253043191, -253041137, -1268125170, -1272393170, -1272425938, -1271376338, -1267184018, -1531426306, -1514481442, -1497699122, -1497636658, -1493655458, -1502040008, -1503018952, -1506029256, -1489472728, -1525145048, -1541863896, -1542898072, -1538704408, -456451591, -459404918, -459388790, -172701558, -139158390, -156983158, -152723318, -161046278, -164192018, -164175634]
+        audio = Audio(chromaprint_fingerprint=first_print, doc_id="blah", url="http://blah.com", context=[{"blah": 1}])
+        db.session.add(audio)
+        db.session.commit()
+        self.model = AudioModel('audio')
+
+    def tearDown(self): # done in our pytest fixture after yield
+        db.session.remove()
+        db.drop_all()
+
+    def test_audio_basic_http_responses_with_doc_id(self):
+        url = 'file:///app/app/test/data/test_audio_1.mp3'
+        with patch('requests.post') as mock_post_request:
+            r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
+            r.set(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", {"response": {"hash_value": [1,2,3]}})
+            mock_response = Mock()
+            mock_response.text = json.dumps({
+                'message': 'Message pushed successfully',
+                'queue': 'audio__Model',
+                'body': {
+                    'callback_url': 'http://alegre:3100/presto/receive/add_item/audio',
+                    'id': "1c63abe0-aeb4-4bac-8925-948b69c32d0d",
+                    'url': 'http://example.com/blah.mp3',
+                    'text': None,
+                    'raw': {
+                        'doc_id': "1c63abe0-aeb4-4bac-8925-948b69c32d0d",
+                        'url': 'http://example.com/blah.mp3'
+                    }
+                }
+            })
+            mock_post_request.return_value = mock_response
+            response = self.client.post('/audio/similarity/', data=json.dumps({
+                'url': url,
+                'doc_id': "1c63abe0-aeb4-4bac-8925-948b69c32d0d",
+                'context': {
+                    'team_id': 1,
+                }
+            }), content_type='application/json')
+        result = json.loads(response.data.decode())
+        self.assertEqual(result['message'], "Message pushed successfully")
+
+    def test_audio_basic_http_responses(self):
+        url = 'file:///app/app/test/data/test_audio_1.mp3'
+        with patch('requests.post') as mock_post_request:
+            r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
+            r.set(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", {"response": {"hash_value": [1,2,3]}})
+            mock_response = Mock()
+            mock_response.text = json.dumps({
+                'message': 'Message pushed successfully',
+                'queue': 'audio__Model',
+                'body': {
+                    'callback_url': 'http://alegre:3100/presto/receive/add_item/audio',
+                    'id': "1c63abe0-aeb4-4bac-8925-948b69c32d0d",
+                    'url': 'http://example.com/blah.mp3',
+                    'text': None,
+                    'raw': {
+                        'doc_id': "1c63abe0-aeb4-4bac-8925-948b69c32d0d",
+                        'url': 'http://example.com/blah.mp3'
+                    }
+                }
+            })
+            mock_post_request.return_value = mock_response
+            response = self.client.post('/audio/similarity/', data=json.dumps({
+                'url': url,
+                'project_media_id': 1,
+                'context': {
+                    'team_id': 1,
+                }
+            }), content_type='application/json')
+        result = json.loads(response.data.decode())
+        self.assertEqual(result['message'], "Message pushed successfully")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test/test_sync_similarity.py
+++ b/app/test/test_sync_similarity.py
@@ -3,6 +3,7 @@ import json
 from opensearchpy import helpers, OpenSearch, TransportError
 from flask import current_app as app
 import numpy as np
+import redis
 
 from app.main import db
 from app.test.base import BaseTestCase

--- a/app/test/test_sync_similarity.py
+++ b/app/test/test_sync_similarity.py
@@ -8,7 +8,7 @@ from app.main import db
 from app.test.base import BaseTestCase
 from app.main.lib.shared_models.shared_model import SharedModel
 from unittest.mock import patch
-
+from app.main.model.audio import Audio
 class TestSimilarityBlueprint(BaseTestCase):
     def setUp(self):
         super().setUp()

--- a/app/test/test_sync_similarity.py
+++ b/app/test/test_sync_similarity.py
@@ -28,7 +28,7 @@ class TestSimilarityBlueprint(BaseTestCase):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
         with patch('requests.post') as mock_post_request:
             r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
-            r.set(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", {"response": {"hash_value": [1,2,3]}})
+            r.set(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", json.dumps({"response": {"hash_value": [1,2,3]}}))
             mock_response = Mock()
             mock_response.text = json.dumps({
                 'message': 'Message pushed successfully',
@@ -59,7 +59,7 @@ class TestSimilarityBlueprint(BaseTestCase):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
         with patch('requests.post') as mock_post_request:
             r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
-            r.set(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", {"response": {"hash_value": [1,2,3]}})
+            r.set(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", json.dumps({"response": {"hash_value": [1,2,3]}}))
             mock_response = Mock()
             mock_response.text = json.dumps({
                 'message': 'Message pushed successfully',


### PR DESCRIPTION
## Description
We are adding a new pair of endpoints for similarity lookup on alegre - one that is explicitly, consistently synchronous, and one that is explicitly, consistently, asynchronous. This is the first of these, the sync endpoint. We're extending existing audio model capacity to afford for a unique flow to explicitly run a blocking search, and calling into the code through that.

Reference: CV2-3827

## How has this been tested?
This has been tested locally - while we are updating tons of tests in the audio test suite, we're aiming to *not* cause any changes to the HTTP interface in the existing audio tests. We're also adding tests for the new sync endpoint to help illustrate the package being sent through to it.

