### PR TITLE
Cv2 3827 update contract

### DIFF
--- a/app/main/lib/shared_models/audio_model.py
+++ b/app/main/lib/shared_models/audio_model.py
@@ -92,7 +92,7 @@ class AudioModel(SharedModel):
 
     def add(self, task):
         try:
-            audio = Audio(chromaprint_fingerprint=task.get("hash_value"), doc_id=task.get("doc_id"), url=task.get("url"), context=task.get("context", {}))
+            audio = Audio(chromaprint_fingerprint=task.get("hash_value"), doc_id=task.get("doc_id", task.get("raw", {}).get("doc_id")), url=task.get("url"), context=task.get("context", task.get("raw", {}).get("context")))
             try:
               audio = self.save(audio)
             except sqlalchemy.exc.IntegrityError:

--- a/app/test/test_audio_similarity.py
+++ b/app/test/test_audio_similarity.py
@@ -144,6 +144,14 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         self.assertEqual(sorted(result['requested'].keys()), ['context', 'doc_id', 'url'])
         self.assertEqual(sorted(result['result'].keys()), ['url'])
 
+    def test_add_by_doc_id_embedded_raw(self):
+        url = 'file:///app/app/test/data/test_audio_1.mp3'
+        result = self.model.add({"url": url, "raw": {'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "context": {"has_custom_id": True}}})
+        self.assertIsInstance(result, dict)
+        self.assertEqual(sorted(result.keys()), ['requested', 'result', 'success'])
+        self.assertEqual(sorted(result['requested'].keys()), ['context', 'doc_id', 'url'])
+        self.assertEqual(sorted(result['result'].keys()), ['url'])
+
     def test_search_by_doc_id(self):
         url = 'file:///app/app/test/data/test_audio_1.mp3'
         hash_key = "blah"

--- a/app/test/test_audio_similarity.py
+++ b/app/test/test_audio_similarity.py
@@ -149,7 +149,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         result = self.model.add({"url": url, "raw": {'doc_id': "Y2hlY2stcHJvamVjdF9tZWRpYS01NTQ1NzEtdmlkZW8", "context": {"has_custom_id": True}}})
         self.assertIsInstance(result, dict)
         self.assertEqual(sorted(result.keys()), ['requested', 'result', 'success'])
-        self.assertEqual(sorted(result['requested'].keys()), ['context', 'doc_id', 'url'])
+        self.assertEqual(sorted(result['requested'].keys()), ['raw', 'url'])
         self.assertEqual(sorted(result['result'].keys()), ['url'])
 
     def test_search_by_doc_id(self):


### PR DESCRIPTION
## Description
Changes to accommodate the sync endpoint accidentally caused a regression on the existing expectations. This fix accommodates both more comprehensively.

Reference: CV2-3827

## How has this been tested?
We're adding new tests to explicitly make sure that this regression can't happen again

