### PR TITLE
CV2-2875 rework response structures

### DIFF
--- a/app/main/controller/presto_controller.py
+++ b/app/main/controller/presto_controller.py
@@ -27,9 +27,9 @@ class PrestoResource(Resource):
         app.logger.info(f"PrestoResource {action}")
         if action == "add_item":
             app.logger.info(f"Data looks like {data}")
-            result = similarity.callback_add_item(dict(**data.get("body"), **data.get("response", {})), model_type)
+            result = similarity.callback_add_item(data.get("body"), model_type)
             if data.get("body", {}).get("raw", {}).get("final_task") == "search":
-                result = similarity.callback_search_item(dict(**data.get("body"), **data.get("response", {})), model_type)
+                result = similarity.callback_search_item(data.get("body"), model_type)
             callback_url = data.get("body", {}).get("raw", {}).get("callback_url", app.config['CHECK_API_HOST']) or app.config['CHECK_API_HOST']
             if data.get("body", {}).get("raw", {}).get("requires_callback"):
                 app.logger.info(f"Sending callback to {callback_url} for {action} for model of {model_type} with body of {result}")

--- a/app/main/lib/shared_models/audio_model.py
+++ b/app/main/lib/shared_models/audio_model.py
@@ -213,7 +213,7 @@ class AudioModel(SharedModel):
         # Warning: this is a blocking hold to wait until we get a response in 
         # a redis key that we've received something from presto.
         result = Presto.blocked_response(response, "audio")
-        audio.chromaprint_fingerprint = result["response"]["hash_value"]
+        audio.chromaprint_fingerprint = result["body"]["hash_value"]
         if audio:
             matches = self.search_by_hash_value(audio.chromaprint_fingerprint, task.get("threshold", 0.0), context)
             if temporary:
@@ -248,7 +248,7 @@ class AudioModel(SharedModel):
             limit = body.get("raw", {}).get("limit")
             if not body.get("raw"):
                 body["raw"] = {}
-            body["hash_value"] = task.get("response", {}).get("hash_value")
+            body["hash_value"] = task.get("body", {}).get("hash_value")
         else:
             body = task
             threshold = body.get('threshold', 0.0)
@@ -263,7 +263,7 @@ class AudioModel(SharedModel):
             # Warning: this is a blocking hold to wait until we get a response in 
             # a redis key that we've received something from presto.
             result = Presto.blocked_response(response, "audio")
-            audio.chromaprint_fingerprint = result["response"]["hash_value"]
+            audio.chromaprint_fingerprint = result["body"]["hash_value"]
             context = self.get_context_for_search(result["body"]["raw"])
         if audio:
             matches = self.search_by_hash_value(audio.chromaprint_fingerprint, threshold, context)

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -141,7 +141,7 @@ def callback_search_item(item, similarity_type):
 def delete_item(item, similarity_type):
   app.logger.info(f"[Alegre Similarity] [Item {item}, Similarity type: {similarity_type}] Deleting item")
   if similarity_type == "audio":
-    response = audio_model().get_shared_model_response(model_response_package(item, "delete"))
+    response = audio_model().delete(model_response_package(item, "delete"))
   elif similarity_type == "video":
     response = video_model().get_shared_model_response(model_response_package(item, "delete"))
   elif similarity_type == "image":

--- a/app/test/test_audio_similarity.py
+++ b/app/test/test_audio_similarity.py
@@ -282,7 +282,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         #db.session.add(audio)
         db.session.add(audio2)
         db.session.commit()
-        result = self.model.search({"body": {"url": url1, "context": {"blah": 3}, "response": {"hash_value": [1,2,3]}}})
+        result = self.model.search({"body": {"url": url1, "context": {"blah": 3}, "hash_value": [1,2,3]}})
         second_case = [e for e in result["result"] if e["url"] == url2][0]
         self.assertIsInstance(second_case, dict)
         self.assertEqual(sorted(second_case.keys()), ['chromaprint_fingerprint', 'context', 'doc_id', 'id', 'model', 'score', 'url'])

--- a/app/test/test_audio_similarity.py
+++ b/app/test/test_audio_similarity.py
@@ -264,7 +264,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         #db.session.add(audio)
         db.session.add(audio2)
         db.session.commit()
-        result = self.model.search({"body": {"url": url1, "context": {"blah": 2}, "threshold": 0.9}, "response": {"hash_value": [e-1 for e in first_print]}})#.get("body")
+        result = self.model.search({"body": {"url": url1, "context": {"blah": 2}, "threshold": 0.9, "hash_value": [e-1 for e in first_print]}})#.get("body")
         second_case = [e for e in result["result"] if e["url"] == url2]
         self.assertGreater(len(second_case),0)
         second_case = second_case[0]
@@ -282,7 +282,7 @@ class TestAudioSimilarityBlueprint(BaseTestCase):
         #db.session.add(audio)
         db.session.add(audio2)
         db.session.commit()
-        result = self.model.search({"body": {"url": url1, "context": {"blah": 3}}, "response": {"hash_value": [1,2,3]}})
+        result = self.model.search({"body": {"url": url1, "context": {"blah": 3}, "response": {"hash_value": [1,2,3]}}})
         second_case = [e for e in result["result"] if e["url"] == url2][0]
         self.assertIsInstance(second_case, dict)
         self.assertEqual(sorted(second_case.keys()), ['chromaprint_fingerprint', 'context', 'doc_id', 'id', 'model', 'score', 'url'])

--- a/app/test/test_presto.py
+++ b/app/test/test_presto.py
@@ -44,8 +44,6 @@ class TestPrestoBlueprint(BaseTestCase):
                     "requires_callback": False,
                     "final_task": "search",
                 },
-            },
-            "response": {
                 "hash_value": [
                     377259661,
                     376226445,

--- a/app/test/test_sync_similarity.py
+++ b/app/test/test_sync_similarity.py
@@ -27,7 +27,7 @@ class TestSyncSimilarityBlueprint(BaseTestCase):
         with patch('requests.post') as mock_post_request:
             r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
             r.delete(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d")
-            r.lpush(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", json.dumps({"response": {"hash_value": [1,2,3]}}))
+            r.lpush(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", json.dumps({"body": {"hash_value": [1,2,3]}}))
             mock_response = Mock()
             mock_response.text = json.dumps({
                 'message': 'Message pushed successfully',
@@ -62,7 +62,7 @@ class TestSyncSimilarityBlueprint(BaseTestCase):
         with patch('requests.post') as mock_post_request:
             r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
             r.delete(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d")
-            r.lpush(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", json.dumps({"response": {"hash_value": [1,2,3]}}))
+            r.lpush(f"audio_1c63abe0-aeb4-4bac-8925-948b69c32d0d", json.dumps({"body": {"hash_value": [1,2,3]}}))
             mock_response = Mock()
             mock_response.text = json.dumps({
                 'message': 'Message pushed successfully',


### PR DESCRIPTION
## Description
In light of more prep for getting ready to build out other modalities, I'm slightly reworking response structures to make them more consistent across modalities - most of the work is on the presto end, but it will require a few tweaks on this side as well.

Reference: 2875

## How has this been tested?
This has been tested by updating fixtures on local unit tests, and running integration tests against this PR to confirm that the updated fixtures actually look the same as the real data coming out of presto. Should be good to go!