### PR TITLE
CV2-3828 update contract

### DIFF
--- a/app/main/controller/image_classification_controller.py
+++ b/app/main/controller/image_classification_controller.py
@@ -20,10 +20,7 @@ class ImageClassificationResource(Resource):
     @api.doc('Classify and label an image')
     @api.doc(params={'uri': 'image URL to be queried for classification'})
     def get(self):
-        if(request.args.get('uri')):
-            uri=request.args.get('uri')
-        else:
-            uri=request.json['uri']
+        uri=request.json['uri']
         # Read from cache first.
         r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])
         key = 'image_classification:' + hashlib.md5(uri.encode('utf-8')).hexdigest()

--- a/app/main/controller/image_ocr_controller.py
+++ b/app/main/controller/image_ocr_controller.py
@@ -20,17 +20,10 @@ class ImageOcrResource(Resource):
     @api.response(200, 'text successfully extracted.')
     @api.doc('Perform text extraction from an image')
     @api.doc(params={'url': 'url of image to extract text from'})
-    @api.expect(ocr_request, validate=True)
     @tenacity.retry(wait=tenacity.wait_exponential(multiplier=1, min=2, max=5), stop=(tenacity.stop_after_attempt(3) | tenacity.stop_after_delay(10)), after=_after_log, reraise=True)
     def get(self):
-        print(request.args)
-        print(request.json)
         image = vision.types.Image()
-        if(request.args.get('url')):
-            image.source.image_uri=request.args.get('url')
-        else:
-            image.source.image_uri = request.json['url']
-
+        image.source.image_uri = request.json['url']
         response = CLIENT.document_text_detection(image=image)
 
         if response.error.message:

--- a/app/main/controller/image_ocr_controller.py
+++ b/app/main/controller/image_ocr_controller.py
@@ -20,9 +20,11 @@ class ImageOcrResource(Resource):
     @api.response(200, 'text successfully extracted.')
     @api.doc('Perform text extraction from an image')
     @api.doc(params={'url': 'url of image to extract text from'})
-
+    @api.expect(ocr_request, validate=True)
     @tenacity.retry(wait=tenacity.wait_exponential(multiplier=1, min=2, max=5), stop=(tenacity.stop_after_attempt(3) | tenacity.stop_after_delay(10)), after=_after_log, reraise=True)
     def get(self):
+        print(request.args)
+        print(request.json)
         image = vision.types.Image()
         if(request.args.get('url')):
             image.source.image_uri=request.args.get('url')

--- a/app/main/controller/image_similarity_controller.py
+++ b/app/main/controller/image_similarity_controller.py
@@ -9,7 +9,7 @@ image_similarity_request = api.model('image_similarity_request', {
   'url': fields.String(required=False, description='image URL to be stored or queried for similarity'),
   'doc_id': fields.String(required=False, description='image ID to constrain uniqueness'),
   'threshold': fields.Float(required=False, default=0.9, description='minimum score to consider, between 0.0 and 1.0 (defaults to 0.9)'),
-  'context': JsonObject(required=False, default=[], description='context')
+  'context': JsonObject(required=False, default={}, description='context')
 })
 
 @api.route('/')

--- a/app/main/controller/langid_controller.py
+++ b/app/main/controller/langid_controller.py
@@ -21,12 +21,8 @@ def _after_log(retry_state):
 class LangidResource(Resource):
     def respond(self):
         provider = app.config['PROVIDER_LANGID']
-        if(request.args):
-            text=request.args.get('text')
-            if 'provider' in request.args: provider = request.args.get('provider')
-        else:
-            text=request.json['text']
-            if 'provider' in request.json: provider = request.json['provider']
+        text=request.json['text']
+        if 'provider' in request.json: provider = request.json['provider']
 
         # Read from cache first.
         r = redis.Redis(host=app.config['REDIS_HOST'], port=app.config['REDIS_PORT'], db=app.config['REDIS_DATABASE'])

--- a/app/main/lib/image_similarity.py
+++ b/app/main/lib/image_similarity.py
@@ -34,13 +34,12 @@ def save(image):
     flag_modified(existing, 'context')
   except NoResultFound as e:
     # Otherwise, add new image, but with context as an array
-    if image.context:
+    if not isinstance(image.context, list):
       image.context = [image.context]
     db.session.add(image)
   except Exception as e:
     db.session.rollback()
     raise e
-
   try:
     db.session.commit()
   except Exception as e:

--- a/app/main/lib/shared_models/audio_model.py
+++ b/app/main/lib/shared_models/audio_model.py
@@ -46,7 +46,7 @@ class AudioModel(SharedModel):
         except NoResultFound as e:
             # Otherwise, add new audio, but with context as an array
             app.logger.debug("Adding Audio object that looks like "+str(audio.__dict__))
-            if audio.context and not isinstance(audio.context, list):
+            if not isinstance(audio.context, list):
                 audio.context = [audio.context]
                 app.logger.debug("Set context to "+str(audio.context))
             db.session.add(audio)

--- a/app/test/pact/check_api-alegre.json
+++ b/app/test/pact/check_api-alegre.json
@@ -1,4 +1,4 @@
-
+{
   "consumer": {
     "name": "Check API"
   },

--- a/app/test/pact/check_api-alegre.json
+++ b/app/test/pact/check_api-alegre.json
@@ -13,7 +13,7 @@
         "method": "get",
         "path": "/image/similarity/",
         "headers": {"Content-Type": "application/json"},
-        "body": "{\"url\": \"https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg\", \"threshold\": 0.89, \"context\": {\"ball\": 1}}"
+        "body": {"url": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg", "threshold": 0.89, "context": {"ball": 1}}
       },
       "response": {
         "status": 200,
@@ -43,7 +43,7 @@
         "method": "post",
         "path": "/text/langid/",
         "headers": {"Content-Type": "application/json"},
-        "body": "{\"text\": \"This is a test\"}"
+        "body": {"text": "This is a test"}
       },
       "response": {
         "status": 200,
@@ -73,7 +73,7 @@
         "method": "get",
         "path": "/image/ocr/",
         "headers": {"Content-Type": "application/json"},
-        "body": "{\"url\": \"https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg\"}"
+        "body": {"url": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg"}
       },
       "response": {
         "status": 200,
@@ -97,7 +97,7 @@
         "method": "get",
         "path": "/image/classification/",
         "headers": {"Content-Type": "application/json"},
-        "body": "{\"url\": \"https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg\"}"
+        "body": {"uri": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg"}
       },
       "response": {
         "status": 200,

--- a/app/test/pact/check_api-alegre.json
+++ b/app/test/pact/check_api-alegre.json
@@ -79,7 +79,7 @@
         "method": "get",
         "path": "/image/ocr/",
         "body": {
-            "uri": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg"
+            "url": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg"
         }
       },
       "response": {

--- a/app/test/pact/check_api-alegre.json
+++ b/app/test/pact/check_api-alegre.json
@@ -1,4 +1,4 @@
-{
+
   "consumer": {
     "name": "Check API"
   },
@@ -12,7 +12,10 @@
       "request": {
         "method": "get",
         "path": "/image/similarity/",
-        "query": "url=https%3A%2F%2Fi.pinimg.com%2F564x%2F0f%2F73%2F57%2F0f7357637b2b203e9f32e73c24d126d7.jpg&threshold=0.89"
+        "body": {
+            "uri": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg",
+            "threshold": 0.89
+        }
       },
       "response": {
         "status": 200,
@@ -27,6 +30,7 @@
               "phash": 25131435933209733,
               "url": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg",
               "context": {
+                
               },
               "score": 1.0
             }
@@ -74,7 +78,9 @@
       "request": {
         "method": "get",
         "path": "/image/ocr/",
-        "query": "url=https%3A%2F%2Fi.pinimg.com%2F564x%2F0f%2F73%2F57%2F0f7357637b2b203e9f32e73c24d126d7.jpg"
+        "body": {
+            "uri": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg"
+        }
       },
       "response": {
         "status": 200,
@@ -97,7 +103,9 @@
       "request": {
         "method": "get",
         "path": "/image/classification/",
-        "query": "uri=https%3A%2F%2Fi.pinimg.com%2F564x%2F0f%2F73%2F57%2F0f7357637b2b203e9f32e73c24d126d7.jpg"
+        "body": {
+            "uri": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg"
+        }
       },
       "response": {
         "status": 200,

--- a/app/test/pact/check_api-alegre.json
+++ b/app/test/pact/check_api-alegre.json
@@ -12,6 +12,9 @@
       "request": {
         "method": "get",
         "path": "/image/similarity/",
+        "headers": {
+          "Content-Type": "application/json"
+        },
         "body": {
             "uri": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg",
             "threshold": 0.89
@@ -78,6 +81,9 @@
       "request": {
         "method": "get",
         "path": "/image/ocr/",
+        "headers": {
+          "Content-Type": "application/json"
+        },
         "body": {
             "url": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg"
         }
@@ -103,6 +109,9 @@
       "request": {
         "method": "get",
         "path": "/image/classification/",
+        "headers": {
+          "Content-Type": "application/json"
+        },
         "body": {
             "uri": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg"
         }

--- a/app/test/pact/check_api-alegre.json
+++ b/app/test/pact/check_api-alegre.json
@@ -12,13 +12,8 @@
       "request": {
         "method": "get",
         "path": "/image/similarity/",
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "body": {
-            "uri": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg",
-            "threshold": 0.89
-        }
+        "headers": {"Content-Type": "application/json"},
+        "body": "{\"url\": \"https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg\", \"threshold\": 0.89, \"context\": {\"ball\": 1}}"
       },
       "response": {
         "status": 200,
@@ -32,9 +27,9 @@
               "sha256": "ebf6b1968d01298a193eb6a8d0f81590dd70e950d1481ad9c4c5b3f43d3f5258",
               "phash": 25131435933209733,
               "url": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg",
-              "context": {
-                
-              },
+              "context": [{
+                "ball": 1
+              }],
               "score": 1.0
             }
           ]
@@ -47,12 +42,8 @@
       "request": {
         "method": "post",
         "path": "/text/langid/",
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "body": {
-          "text": "This is a test"
-        }
+        "headers": {"Content-Type": "application/json"},
+        "body": "{\"text\": \"This is a test\"}"
       },
       "response": {
         "status": 200,
@@ -81,12 +72,8 @@
       "request": {
         "method": "get",
         "path": "/image/ocr/",
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "body": {
-            "url": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg"
-        }
+        "headers": {"Content-Type": "application/json"},
+        "body": "{\"url\": \"https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg\"}"
       },
       "response": {
         "status": 200,
@@ -109,12 +96,8 @@
       "request": {
         "method": "get",
         "path": "/image/classification/",
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "body": {
-            "uri": "https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg"
-        }
+        "headers": {"Content-Type": "application/json"},
+        "body": "{\"url\": \"https://i.pinimg.com/564x/0f/73/57/0f7357637b2b203e9f32e73c24d126d7.jpg\"}"
       },
       "response": {
         "status": 200,


### PR DESCRIPTION
## Description
This is a super small update to just change the contract tests to only use body instead of url query params. I've verified that all controllers support both bodies or query params, so we'll sunset query params eventually, but this shouldn't break anything in the interim.

Reference: 3828

## How has this been tested?
This is breaking tests on check-api, so that's how it's being tested right now!

## Have you considered secure coding practices when writing this code?
Not particularly relevant here
