### PR TITLE
Keep doc_id when storing in Elastic/Opensearch

### DIFF
--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -72,7 +72,7 @@ def get_body_for_text_document(params, mode):
       params['content'] = None
 
     if mode == 'store':
-      allow_list = set(['language', 'content', 'created_at', 'models', 'context', 'callback_url'])
+      allow_list = set(['doc_id', 'language', 'content', 'created_at', 'models', 'context', 'callback_url'])
       keys_to_remove = params.keys() - allow_list
       app.logger.info(
         f"[Alegre Similarity] get_body_for_text_document:running in `store' mode. Removing {keys_to_remove}")


### PR DESCRIPTION
Current code strips doc_id before storing items in Opensearch/Elastisearch. This is an error and will result in deletes and updates not functioning correctly. Fixing here.

## Description
Please include a very brief high-level description of the problem or feature and technical details or specific code changes on PR

Reference: CV2-4052

## How has this been tested?
Has it been tested locally? Are there automated tests?

## Have you considered secure coding practices when writing this code?
Please list any security concerns that may be relevant.
