### PR TITLE
CV2-3828 get rid of now-unnecessary casting lines and more robust lookup on temp storage of audio

### DIFF
--- a/app/main/controller/audio_similarity_controller.py
+++ b/app/main/controller/audio_similarity_controller.py
@@ -33,7 +33,4 @@ class AudioSimilaritySearchResource(Resource):
     def post(self):
         args = request.json
         app.logger.debug(f"Args are {args}")
-        for key in ["context", "models", "per_model_threshold", "vector"]:
-            if args and args.get(key) and isinstance(args.get(key), str):
-                args[key] = json.loads(args.get(key))
         return similarity.get_similar_items(args, "audio")

--- a/app/main/controller/similarity_async_controller.py
+++ b/app/main/controller/similarity_async_controller.py
@@ -26,9 +26,6 @@ class AsyncSimilarityResource(Resource):
     def post(self, similarity_type):
         args = request.json
         app.logger.debug(f"Args are {args}")
-        for key in ["context", "models", "per_model_threshold", "vector"]:
-            if args and args.get(key) and isinstance(args.get(key), str):
-                args[key] = json.loads(args.get(key))
         if similarity_type == "text":
             package = similarity.get_body_for_text_document(args, 'query')
         else:

--- a/app/main/controller/similarity_controller.py
+++ b/app/main/controller/similarity_controller.py
@@ -47,7 +47,4 @@ class SimilaritySearchResource(Resource):
     def post(self):
       args = request.json
       app.logger.debug(f"Args are {args}")
-      for key in ["context", "models", "per_model_threshold", "vector"]:
-        if args and args.get(key) and isinstance(args.get(key), str):
-          args[key] = json.loads(args.get(key))
       return similarity.get_similar_items(similarity.get_body_for_text_document(args, mode='query'), "text")

--- a/app/main/controller/similarity_sync_controller.py
+++ b/app/main/controller/similarity_sync_controller.py
@@ -24,9 +24,6 @@ class SyncSimilarityResource(Resource):
     def post(self, similarity_type):
         args = request.json
         app.logger.debug(f"Args are {args}")
-        for key in ["context", "models", "per_model_threshold", "vector"]:
-            if args and args.get(key) and isinstance(args.get(key), str):
-                args[key] = json.loads(args.get(key))
         if similarity_type == "text":
             package = similarity.get_body_for_text_document(args, 'query')
         else:

--- a/app/main/controller/video_similarity_controller.py
+++ b/app/main/controller/video_similarity_controller.py
@@ -33,7 +33,4 @@ class VideoSimilaritySearchResource(Resource):
     def post(self):
         args = request.json
         app.logger.debug(f"Args are {args}")
-        for key in ["context", "models", "per_model_threshold", "vector"]:
-            if args and args.get(key) and isinstance(args.get(key), str):
-                args[key] = json.loads(args.get(key))
         return similarity.get_similar_items(args, "video")

--- a/app/main/lib/shared_models/audio_model.py
+++ b/app/main/lib/shared_models/audio_model.py
@@ -191,9 +191,7 @@ class AudioModel(SharedModel):
                 task["doc_id"] = str(uuid.uuid4())
             app.logger.debug("Adding temporary audio object of "+str(task))
             self.add(task)
-            audios = db.session.query(Audio).filter(Audio.doc_id==task.get("doc_id")).all()
-            if audios and not audio:
-                audio = audios[0]
+            audio = self.get_by_doc_id_or_url(task)
         return audio, temporary
 
     def get_context_for_search(self, task):


### PR DESCRIPTION

## Description
Solves for a problem looking up existing items, manifesting in broken audio matches and several sentry items:
https://meedan.sentry.io/issues/4678392010/events/1c93619c47fe4248aac8358bacf9322b/?project=4504690947653632
https://meedan.sentry.io/issues/4678391960/?environment=qa&project=4504691019677696&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h&stream_index=0

Reference: 3828

## How has this been tested?
tested on QA box while fixing problem

## Have you considered secure coding practices when writing this code?
This is definitely an improvement on what we were doing in that we are using an established pattern for lookup instead of yolo'ing it!