### PR TITLE
upgrade redis to 6.2 and specify travis distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: jammy
 before_install:
 - openssl aes-256-cbc -K $encrypted_e34ab48306dd_key -iv $encrypted_e34ab48306dd_iv
   -in .env_file.enc -out .env_file -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       ELASTICSEARCH_URL: http://elasticsearch:9200
   redis:
-    image: redis:5
+    image: redis:6.2
     ports:
       - "6379:6379"
     volumes:


### PR DESCRIPTION
## Description
We had to upgrade Redis in Pender due to the Sidekiq upgrade, and Redis is on 6.2 on our qa and live environment. So we are taking this opportunity to update in all repos.

Regarding the distro, we had issues running the tests on Travis, in Pender changing the disto fixed it. So I'm trying that here as well.


Reference: 3480

## How has this been tested?
Passed alegre's automated tests, and passed integration tests.

