### PR TITLE
Fixing a typo

### DIFF
--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -148,7 +148,7 @@ def delete_item(item, similarity_type):
 
 def get_similar_items(item, similarity_type):
   app.logger.info(f"[Alegre Similarity] [Item {item}, Similarity type: {similarity_type}] searching on item")
-  reponse = None
+  response = None
   if similarity_type == "video":
     response = video_model().get_shared_model_response(model_response_package(item, "search"))
   elif similarity_type == "text":


### PR DESCRIPTION
## Description

A typo that is actually causing an error triggered by Sentry:

```
UnboundLocalError
local variable 'response' referenced before assignment
```

References: CV2-4044 and Sentry issue 4807084657.