### PR TITLE
update base image for build step in ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,12 +17,13 @@ build_qa:
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
     - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_API_BASE_URL
-    - docker build --build-arg DEPLOY_BRANCH=develop --build-arg TIMESTAMP=$(date '+%Y%m%d%H%M%S') -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/alegre/api:$CI_COMMIT_SHA"  .
+    - docker build --cache-from "$ECR_API_BASE_URL/qa/alegre/api:latest" -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/alegre/api:$CI_COMMIT_SHA" -t "$ECR_API_BASE_URL/qa/alegre/api:latest" .
     - docker push "$ECR_API_BASE_URL/qa/alegre/api:$CI_COMMIT_SHA"
     - docker push "$ECR_API_BASE_URL/qa/alegre/api:latest"
   only:
     - develop
     - feature/CV2-3482_deploy-new-model
+    - quickfix/gitlab-ci-build-image
 
 deploy_qa:
   image: python:3-alpine
@@ -75,7 +76,7 @@ build_live:
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
     - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_API_BASE_URL
-    - docker build --build-arg DEPLOY_BRANCH=develop --build-arg TIMESTAMP=$(date '+%Y%m%d%H%M%S') -f production/Dockerfile -t "$ECR_API_BASE_URL/live/alegre/api:$CI_COMMIT_SHA"  .
+    - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/live/alegre/api:$CI_COMMIT_SHA"  .
     - docker push "$ECR_API_BASE_URL/live/alegre/api:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
   - deploy_live
 
 build_qa:
-  image: docker:latest
+  image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
   services:
     - docker:dind
   tags:
@@ -16,13 +16,10 @@ build_qa:
     AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
-    - apk add --no-cache curl jq python3 py3-pip git
-    - pip install awscli==1.29.59
-    - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
-    - docker build -f production/Dockerfile --cache-from "$QA_ECR_API_BASE_URL:latest" -t "$QA_ECR_API_BASE_URL:$CI_COMMIT_SHA" -t "$QA_ECR_API_BASE_URL:latest" .
-    - docker push "$QA_ECR_API_BASE_URL:$CI_COMMIT_SHA"
-    - docker push "$QA_ECR_API_BASE_URL:latest"
+    - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_API_BASE_URL
+    - docker build --build-arg DEPLOY_BRANCH=develop --build-arg TIMESTAMP=$(date '+%Y%m%d%H%M%S') -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/alegre/api:$CI_COMMIT_SHA"  .
+    - docker push "$ECR_API_BASE_URL/qa/alegre/api:$CI_COMMIT_SHA"
+    - docker push "$ECR_API_BASE_URL/qa/alegre/api:latest"
   only:
     - develop
     - feature/CV2-3482_deploy-new-model
@@ -66,7 +63,7 @@ deploy_qa:
     - feature/CV2-3482_deploy-new-model
 
 build_live:
-  image: docker:latest
+  image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
   services:
     - docker:dind
   tags:
@@ -77,12 +74,9 @@ build_live:
     AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
-    - apk add --no-cache curl jq python3 py3-pip git
-    - pip install awscli==1.29.59
-    - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
-    - docker build -f production/Dockerfile -t "$LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA" -t "$LIVE_ECR_API_BASE_URL:latest" .
-    - docker push "$LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA"
+    - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_API_BASE_URL
+    - docker build --build-arg DEPLOY_BRANCH=develop --build-arg TIMESTAMP=$(date '+%Y%m%d%H%M%S') -f production/Dockerfile -t "$ECR_API_BASE_URL/live/alegre/api:$CI_COMMIT_SHA"  .
+    - docker push "$ECR_API_BASE_URL/live/alegre/api:$CI_COMMIT_SHA"
   only:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,6 @@ build_qa:
   only:
     - develop
     - feature/CV2-3482_deploy-new-model
-    - quickfix/gitlab-ci-build-image
 
 deploy_qa:
   image: python:3-alpine


### PR DESCRIPTION
## Description

use gitlab-provided base image to avoid pip issues, also use actual base url for ecr