### PR TITLE
Fixing the Vector size in the migration code from 256 to 512

### DIFF
--- a/migrations/versions/5e823fb0eaaa_create_sscd_column.py
+++ b/migrations/versions/5e823fb0eaaa_create_sscd_column.py
@@ -27,7 +27,7 @@ def upgrade():
           CREATE EXTENSION IF NOT EXISTS vector;
           """)
     )
-    op.add_column('images', sa.Column('sscd', Vector(256), nullable=True))
+    op.add_column('images', sa.Column('sscd', Vector(512), nullable=True))
     # op.create_index(op.f('ix_images_sscd'), 'images', ['sscd'], unique=False)
 
 def downgrade():


### PR DESCRIPTION
## Description
Fixing the Vector size in the migration code from 256 to 512 in `5e823fb0eaaa_create_sscd_column.py`

Reference:  CV2-3700

