### PR TITLE
CV2-4278 flip searching as json bool for get_context_query in audio

### DIFF
--- a/app/main/lib/shared_models/audio_model.py
+++ b/app/main/lib/shared_models/audio_model.py
@@ -99,7 +99,7 @@ class AudioModel(SharedModel):
     @tenacity.retry(wait=tenacity.wait_fixed(0.5), stop=tenacity.stop_after_delay(5), after=_after_log)
     def search_by_context(self, context):
         try:
-            context_query, context_hash = get_context_query(context, True)
+            context_query, context_hash = get_context_query(context)
             if context_query:
                 cmd = """
                   SELECT id, doc_id, url, hash_value, context FROM audios
@@ -123,7 +123,7 @@ class AudioModel(SharedModel):
     @tenacity.retry(wait=tenacity.wait_fixed(0.5), stop=tenacity.stop_after_delay(5), after=_after_log)
     def search_by_hash_value(self, chromaprint_fingerprint, threshold, context):
         try:
-            context_query, context_hash = get_context_query(context, True)
+            context_query, context_hash = get_context_query(context)
             if context_query:
                 cmd = """
                   SELECT audio_similarity_functions();


### PR DESCRIPTION
## Description
Flip bool on audio context query to be in line with image and video since @caiosba found that the behavior on audio is (a) different than image and (b) unwanted

Reference: CV2-4278

## How has this been tested?
Not tested locally yet - I want to see what tests break if any first

## Have you considered secure coding practices when writing this code?
No concerns
