### PR TITLE
Do not deploy audio model now that presto supports this capability.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/alegre/api:latest"
   only:
     - develop
-    - feature/CV2-3482_deploy-new-model
 
 deploy_qa:
   image: python:3-alpine
@@ -53,8 +52,6 @@ deploy_qa:
     - ecs deploy ecs-qa  qa-alegre-multilingual --diff --image qa-alegre-multilingual $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e qa-alegre-multilingual MODEL_NAME paraphrasemultilingualmpnetbasev2 -e qa-alegre-multilingual SENTENCE_TRANSFORMERS_HOME /mnt/models/multilingual-cache -e qa-alegre-multilingual APP alegre -e qa-alegre-multilingual DEPLOY_ENV qa -e qa-alegre-multilingual ALEGRE_PORT 8000 --exclusive-secrets `cat qa-alegre-multilingual.env.args`
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-alegre-video $NAME /qa/alegre/$NAME " >> qa-alegre-video.env.args; done
     - ecs deploy ecs-qa  qa-alegre-video --diff --image qa-alegre-video $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e qa-alegre-video MODEL_NAME video -e qa-alegre-video PERSISTENT_DISK_PATH /mnt/models/video -e qa-alegre-video APP alegre -e qa-alegre-video DEPLOY_ENV qa -e qa-alegre-video ALEGRE_PORT 8000 --exclusive-secrets `cat qa-alegre-video.env.args`
-    - for NAME in `cat env.qa.names`; do echo -n "-s qa-alegre-audio $NAME /qa/alegre/$NAME " >> qa-alegre-audio.env.args; done
-    - ecs deploy ecs-qa  qa-alegre-audio --diff --image qa-alegre-audio $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e qa-alegre-audio MODEL_NAME audio -e qa-alegre-audio APP alegre -e qa-alegre-audio DEPLOY_ENV qa -e qa-alegre-audio ALEGRE_PORT 8000 --exclusive-secrets `cat qa-alegre-audio.env.args`
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-alegre-worker-c $NAME /qa/alegre/$NAME " >> qa-alegre-worker.env.args; done
     - ecs deploy ecs-qa  qa-alegre-worker --diff --image qa-alegre-worker-c $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e qa-alegre-worker-c APP alegre -e qa-alegre-worker-c DEPLOY_ENV qa -e qa-alegre-worker-c ALEGRE_PORT 8000 --exclusive-secrets `cat qa-alegre-worker.env.args`
     - echo "new Image was deployed $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA"
@@ -110,8 +107,6 @@ deploy_live:
     - ecs deploy ecs-live  live-alegre-multilingual --diff --image live-alegre-multilingual $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e live-alegre-multilingual MODEL_NAME paraphrasemultilingualmpnetbasev2 -e live-alegre-multilingual SENTENCE_TRANSFORMERS_HOME /mnt/models/multilingual-cache -e live-alegre-multilingual APP alegre -e live-alegre-multilingual DEPLOY_ENV live -e live-alegre-multilingual ALEGRE_PORT 8000 --exclusive-secrets `cat live-alegre-multilingual.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-alegre-video $NAME /live/alegre/$NAME " >> live-alegre-video.env.args; done
     - ecs deploy ecs-live  live-alegre-video --diff --image live-alegre-video $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e live-alegre-video MODEL_NAME video -e live-alegre-video PERSISTENT_DISK_PATH /mnt/models/video -e live-alegre-video APP alegre -e live-alegre-video DEPLOY_ENV live -e live-alegre-video ALEGRE_PORT 8000 --exclusive-secrets `cat live-alegre-video.env.args`
-    - for NAME in `cat env.live.names`; do echo -n "-s live-alegre-audio $NAME /live/alegre/$NAME " >> live-alegre-audio.env.args; done
-    - ecs deploy ecs-live  live-alegre-audio --diff --image live-alegre-audio $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e live-alegre-audio MODEL_NAME audio -e live-alegre-audio APP alegre -e live-alegre-audio DEPLOY_ENV live -e live-alegre-audio ALEGRE_PORT 8000 --exclusive-secrets `cat live-alegre-audio.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-alegre-worker-c $NAME /live/alegre/$NAME " >> live-alegre-worker.env.args; done
     - ecs deploy ecs-live  live-alegre-worker --diff --image live-alegre-worker-c $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e live-alegre-worker-c APP alegre -e live-alegre-worker-c DEPLOY_ENV live -e live-alegre-worker-c ALEGRE_PORT 8000 --exclusive-secrets `cat live-alegre-worker.env.args`
     - echo "new Image was deployed $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA"


### PR DESCRIPTION
## Description
We have deprecated the audio model in Alegre now that Presto handles this capability. Do not attempt to deploy the audio model into QA or Live.

## How has this been tested?
Syntax of GitLab CI script verified. Successful deployment into QA will confirm this fix is complete.

## Have you considered secure coding practices when writing this code?
There are no security concerns with these changes.