### PR TITLE
CV2-4437 stub out article work to prevent illegal instruction crashes

### DIFF
--- a/app/main/controller/article_controller.py
+++ b/app/main/controller/article_controller.py
@@ -1,7 +1,7 @@
 import sys
 from flask import abort, request, current_app as app
 from flask_restplus import Resource, Namespace, fields
-from newspaper import Article
+# from newspaper import Article
 from app.main import db
 from app.main.model.article import ArticleModel
 
@@ -13,6 +13,7 @@ article_request = api.model('article_request', {
 @api.route('/')
 class ArticleResource(Resource):
     def get_article(self, url):
+        raise Exception("Currently Offline due to LXML issues")
         try:
             article = Article(url)
             article.download()

--- a/app/main/model/article.py
+++ b/app/main/model/article.py
@@ -2,7 +2,7 @@ import io
 import urllib.request
 
 from sqlalchemy.dialects.postgresql import JSONB, ARRAY
-from newspaper.cleaners import DocumentCleaner
+# from newspaper.cleaners import DocumentCleaner
 from urllib.parse import urlparse
 
 from app.main import db
@@ -57,6 +57,7 @@ class ArticleModel(db.Model):
       :returns: ArticleModel object
     """
     if article:
+        raise Exception("Currently Offline due to LXML issues")
         document_cleaner = DocumentCleaner(article.config)
         article.doc = article.config.get_parser().fromstring(article.html)
         article.doc = document_cleaner.clean(article.doc)

--- a/app/test/test_article.py
+++ b/app/test/test_article.py
@@ -7,7 +7,7 @@ from flask import current_app as app
 from unittest.mock import patch
 from unittest import mock
 from google.cloud import vision
-from newspaper import Article
+# from newspaper import Article
 
 from app.main import db
 from app.test.base import BaseTestCase
@@ -21,42 +21,42 @@ class TestArticleBlueprint(BaseTestCase):
         for key in r.scan_iter("image_classification:*"):
             r.delete(key)
 
-    def test_article_api_post_endpoint(self):
-        with patch('app.main.controller.article_controller.ArticleResource.get_article', ) as mock_get_article:
-            article = Article("blah.com")
-            article.set_html(open('./app/test/data/article.html').read())
-            article.parse()
-            article.nlp()
-            mock_get_article.return_value = article
-            response = self.client.post('/article/',
-                data=json.dumps(dict(
-                    url='http://fox13now.com/2013/12/30/new-year-new-laws-obamacare-pot-guns-and-drones/'
-                )),
-                content_type='application/json'
-            )
-            result = json.loads(response.data.decode())
-            self.assertEqual('application/json', response.content_type)
-            self.assertEqual(200, response.status_code)
-            self.assertEqual(sorted(result.keys()), ['authors', 'keywords', 'links', 'movies', 'publish_date', 'source_url', 'summary', 'tags', 'text', 'title', 'top_image'])
+    # def test_article_api_post_endpoint(self):
+    #     with patch('app.main.controller.article_controller.ArticleResource.get_article', ) as mock_get_article:
+    #         article = Article("blah.com")
+    #         article.set_html(open('./app/test/data/article.html').read())
+    #         article.parse()
+    #         article.nlp()
+    #         mock_get_article.return_value = article
+    #         response = self.client.post('/article/',
+    #             data=json.dumps(dict(
+    #                 url='http://fox13now.com/2013/12/30/new-year-new-laws-obamacare-pot-guns-and-drones/'
+    #             )),
+    #             content_type='application/json'
+    #         )
+    #         result = json.loads(response.data.decode())
+    #         self.assertEqual('application/json', response.content_type)
+    #         self.assertEqual(200, response.status_code)
+    #         self.assertEqual(sorted(result.keys()), ['authors', 'keywords', 'links', 'movies', 'publish_date', 'source_url', 'summary', 'tags', 'text', 'title', 'top_image'])
 
-    def test_article_api_get_endpoint(self):
-        with patch('app.main.controller.article_controller.ArticleResource.get_article', ) as mock_get_article:
-            article = Article("blah.com")
-            article.set_html(open('./app/test/data/article.html').read())
-            article.parse()
-            article.nlp()
-            mock_get_article.return_value = article
-            response = self.client.post(
-                '/article/',
-                data=json.dumps(dict(
-                    url='http://fox13now.com/2013/12/30/new-year-new-laws-obamacare-pot-guns-and-drones/'
-                )),
-                content_type='application/json'
-            )
-            result = json.loads(response.data.decode())
-            self.assertEqual('application/json', response.content_type)
-            self.assertEqual(200, response.status_code)
-            self.assertEqual(sorted(result.keys()), ['authors', 'keywords', 'links', 'movies', 'publish_date', 'source_url', 'summary', 'tags', 'text', 'title', 'top_image'])
+    # def test_article_api_get_endpoint(self):
+    #     with patch('app.main.controller.article_controller.ArticleResource.get_article', ) as mock_get_article:
+    #         article = Article("blah.com")
+    #         article.set_html(open('./app/test/data/article.html').read())
+    #         article.parse()
+    #         article.nlp()
+    #         mock_get_article.return_value = article
+    #         response = self.client.post(
+    #             '/article/',
+    #             data=json.dumps(dict(
+    #                 url='http://fox13now.com/2013/12/30/new-year-new-laws-obamacare-pot-guns-and-drones/'
+    #             )),
+    #             content_type='application/json'
+    #         )
+    #         result = json.loads(response.data.decode())
+    #         self.assertEqual('application/json', response.content_type)
+    #         self.assertEqual(200, response.status_code)
+    #         self.assertEqual(sorted(result.keys()), ['authors', 'keywords', 'links', 'movies', 'publish_date', 'source_url', 'summary', 'tags', 'text', 'title', 'top_image'])
 
     def test_article_api_error_response(self):
         with patch('app.main.controller.article_controller.ArticleResource.respond', ) as mock_get_error_response:
@@ -123,21 +123,21 @@ class TestArticleBlueprint(BaseTestCase):
         result = uri_validator(123456789)
         self.assertEqual(False, result)
         
-    def test_article_responds_with_top_node_extracted_links(self):
-        with patch('app.main.controller.article_controller.ArticleResource.get_article', ) as mock_get_article:
-            article = Article("blah.com")
-            article.set_html(open('./app/test/data/article_with_top_node_links.html').read())
-            article.parse()
-            article.nlp()
-            mock_get_article.return_value = article
-            response = self.client.post('/article/',
-                data=json.dumps(dict(
-                    url='https://g1.globo.com/mundo/noticia/2022/05/06/hotel-em-havana-explosao.ghtml'
-                )),
-                content_type='application/json'
-            )
-            result = json.loads(response.data.decode())
-            self.assertGreater(len(result["links"]), 0)
+    # def test_article_responds_with_top_node_extracted_links(self):
+    #     with patch('app.main.controller.article_controller.ArticleResource.get_article', ) as mock_get_article:
+    #         article = Article("blah.com")
+    #         article.set_html(open('./app/test/data/article_with_top_node_links.html').read())
+    #         article.parse()
+    #         article.nlp()
+    #         mock_get_article.return_value = article
+    #         response = self.client.post('/article/',
+    #             data=json.dumps(dict(
+    #                 url='https://g1.globo.com/mundo/noticia/2022/05/06/hotel-em-havana-explosao.ghtml'
+    #             )),
+    #             content_type='application/json'
+    #         )
+    #         result = json.loads(response.data.decode())
+    #         self.assertGreater(len(result["links"]), 0)
 
 
 if __name__ == '__main__':

--- a/app/test/test_article.py
+++ b/app/test/test_article.py
@@ -99,19 +99,19 @@ class TestArticleBlueprint(BaseTestCase):
             self.assertIn("Article Couldn't be parsed", result['message'])
 
 
-    def test_article_download_error(self):
-        with patch('newspaper.Article.download' ) as mock_download:
-            mock_download.return_value = Exception()
-            response = self.client.post(
-                '/article/',
-                data=json.dumps(dict(
-                    url='http://fox13now.com/2013/12/30/new-year-new-laws-obamacare-pot-guns-and-drones/'
-                )),
-                content_type='application/json'
-            )
-            result = json.loads(response.data.decode())
-            self.assertEqual(400, response.status_code)
-
+    # def test_article_download_error(self):
+    #     with patch('newspaper.Article.download' ) as mock_download:
+    #         mock_download.return_value = Exception()
+    #         response = self.client.post(
+    #             '/article/',
+    #             data=json.dumps(dict(
+    #                 url='http://fox13now.com/2013/12/30/new-year-new-laws-obamacare-pot-guns-and-drones/'
+    #             )),
+    #             content_type='application/json'
+    #         )
+    #         result = json.loads(response.data.decode())
+    #         self.assertEqual(400, response.status_code)
+    #
     def test_uri_validator(self):
         url='http://fox13now.com/2013/12/30/new-year-new-laws-obamacare-pot-guns-and-drones/'
         result = uri_validator(url)


### PR DESCRIPTION
## Description
Right now, any attempt to import newspaper3k results in an Illegal Instruction exception that hard-kills the python instance. This requires upgrading to newspaper4k, which requires upgrading Python 3.7 to Python 3.8, which requires upgrading tensorflow, which is a pain. We need to eventually pay down that debt - we are now 6 years behind with our code versions in Alegre - this will only become more painful. In lieu of fixing this today, we are opting to simply gut functionality for newspaper-*-based operations on articles, which should unstick us from the current state, which is that no alegre builds are working.

Reference: CV2-4437

## How has this been tested?
Now works locally and starts up - was not starting at all before. Open question if all tests work but I think they should just go through fine.

## Have you considered secure coding practices when writing this code?
We need to update our package versions...
