### PR TITLE
CV2-4528 Set the PERSISTENT_DISK_PATH for main alegre service.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/alegre/api:latest"
   only:
     - develop
-    - feature/CV2-4518_video-support
 
 deploy_qa:
   image: python:3-alpine
@@ -58,7 +57,6 @@ deploy_qa:
     - echo "new Image was deployed $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA"
   only:
     - develop
-    - feature/CV2-4518_video-support
 
 build_live:
   image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/alegre/api:latest"
   only:
     - develop
+    - feature/CV2-4518_video-support
 
 deploy_qa:
   image: python:3-alpine
@@ -41,7 +42,7 @@ deploy_qa:
     - pip install awscli==1.29.59
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/alegre/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/alegre/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-alegre-c $NAME /qa/alegre/$NAME " >> qa-alegre-c.env.args; done
-    - ecs deploy ecs-qa  qa-alegre --diff --image qa-alegre-c $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e qa-alegre-c APP alegre -e qa-alegre-c DEPLOY_ENV qa -e qa-alegre-c ALEGRE_PORT 8000 --exclusive-secrets `cat qa-alegre-c.env.args`
+    - ecs deploy ecs-qa  qa-alegre --diff --image qa-alegre-c $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e qa-alegre-c APP alegre -e qa-alegre-c PERSISTENT_DISK_PATH /mnt/models/video -e qa-alegre-c DEPLOY_ENV qa -e qa-alegre-c ALEGRE_PORT 8000 --exclusive-secrets `cat qa-alegre-c.env.args`
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-alegre-indiansbert $NAME /qa/alegre/$NAME " >> qa-alegre-indiansbert.env.args; done
     - ecs deploy ecs-qa  qa-alegre-indiansbert --diff --image qa-alegre-indiansbert $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e qa-alegre-indiansbert MODEL_NAME indiansbert -e qa-alegre-indiansbert SENTENCE_TRANSFORMERS_HOME /mnt/models/indiansbert-cache -e qa-alegre-indiansbert APP alegre -e qa-alegre-indiansbert DEPLOY_ENV qa -e qa-alegre-indiansbert ALEGRE_PORT 8000 --exclusive-secrets `cat qa-alegre-indiansbert.env.args`
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-alegre-meantokens $NAME /qa/alegre/$NAME " >> qa-alegre-meantokens.env.args; done
@@ -57,7 +58,7 @@ deploy_qa:
     - echo "new Image was deployed $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA"
   only:
     - develop
-    - feature/CV2-3482_deploy-new-model
+    - feature/CV2-4518_video-support
 
 build_live:
   image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
@@ -96,7 +97,7 @@ deploy_live:
     - pip install awscli==1.29.59
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/alegre/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/alegre/##' > env.live.names
     - for NAME in `cat env.live.names`; do echo -n "-s live-alegre-c $NAME /live/alegre/$NAME " >> live-alegre-c.env.args; done
-    - ecs deploy ecs-live  live-alegre --image live-alegre-c $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e live-alegre-c APP alegre -e live-alegre-c DEPLOY_ENV live -e live-alegre-c ALEGRE_PORT 8000 --exclusive-secrets `cat live-alegre-c.env.args`
+    - ecs deploy ecs-live  live-alegre --image live-alegre-c $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e live-alegre-c APP alegre -e live-alegre-c PERSISTENT_DISK_PATH /mnt/models/video -e live-alegre-c DEPLOY_ENV live -e live-alegre-c ALEGRE_PORT 8000 --exclusive-secrets `cat live-alegre-c.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-alegre-indiansbert $NAME /live/alegre/$NAME " >> live-alegre-indiansbert.env.args; done
     - ecs deploy ecs-live  live-alegre-indiansbert --diff --image live-alegre-indiansbert $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e live-alegre-indiansbert MODEL_NAME indiansbert -e live-alegre-indiansbert SENTENCE_TRANSFORMERS_HOME /mnt/models/indiansbert-cache -e live-alegre-indiansbert APP alegre -e live-alegre-indiansbert DEPLOY_ENV live -e live-alegre-indiansbert ALEGRE_PORT 8000 --exclusive-secrets `cat live-alegre-indiansbert.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-alegre-meantokens $NAME /live/alegre/$NAME " >> live-alegre-meantokens.env.args; done


### PR DESCRIPTION
## Description
This change sets the PERSISTENT_DISK_PATH for the main alegre service.

Reference: CV2-4528

## How has this been tested?
A test deployment from this branch was made into QA, and the main alegre service confirmed to have this value set properly.

## Have you considered secure coding practices when writing this code?
There are no security concerns with this change.