### PR TITLE
CV2-4126 get audio response for video in line with audio response for audio

### DIFF
--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -150,7 +150,7 @@ def callback_search_item(item, similarity_type):
   elif similarity_type == "video":
       video_response = video_model().search(model_response_package(item.get("raw"), "search"))
       # When we search for a video, we need to also search for the audio track of the video against our audio library in case it matches other audio clips.
-      audio_response = audio_model().search(video_model().overload_context_to_denote_content_type(model_response_package(item, "search")))
+      audio_response = audio_model().search(video_model().overload_context_to_denote_content_type(model_response_package(item.get("raw"), "search")))
       response = merge_audio_and_video_responses(video_response, audio_response)
       app.logger.info(f"[Alegre Similarity] CallbackSearchItem: [Item {item}, Similarity type: {similarity_type}] Response looks like {response}")
   elif similarity_type == "image":


### PR DESCRIPTION
## Description
Minor oversight with significant results - lots of false positive videos coming in because a missing `.get("raw")` which is already an established code path for audio-only search

Reference: CV2-4126

## How has this been tested?
Has it been tested locally? Are there automated tests?

## Have you considered secure coding practices when writing this code?
Please list any security concerns that may be relevant.
