### PR TITLE
CV2-4126 deal with canned responses being slightly different formats

### DIFF
--- a/app/main/controller/similarity_async_controller.py
+++ b/app/main/controller/similarity_async_controller.py
@@ -36,7 +36,8 @@ class AsyncSimilarityResource(Resource):
         response, waiting_for_callback = similarity.async_get_similar_items(package, similarity_type)
         if not waiting_for_callback:
             package.pop("created_at", None)
-            result = similarity.callback_search_item({"raw": package, "is_shortcircuited_callback": True}, similarity_type)
+            result = similarity.callback_search_item({"raw": package}, similarity_type)
+            result["is_shortcircuited_callback"] = True
             callback_url = args.get("callback_url", app.config['CHECK_API_HOST']) or app.config['CHECK_API_HOST']
             Webhook.return_webhook(callback_url, "search", similarity_type, result)
         return response

--- a/app/main/controller/similarity_async_controller.py
+++ b/app/main/controller/similarity_async_controller.py
@@ -36,7 +36,7 @@ class AsyncSimilarityResource(Resource):
         response, waiting_for_callback = similarity.async_get_similar_items(package, similarity_type)
         if not waiting_for_callback:
             package.pop("created_at", None)
-            result = similarity.callback_search_item({"raw": package}, similarity_type)
+            result = similarity.callback_search_item({"raw": package, "is_shortcircuited_callback": True}, similarity_type)
             callback_url = args.get("callback_url", app.config['CHECK_API_HOST']) or app.config['CHECK_API_HOST']
             Webhook.return_webhook(callback_url, "search", similarity_type, result)
         return response


### PR DESCRIPTION
## Description
Responses from a "canned" response from Alegre to Check API are slightly different such that Check API can't affirmatively confirm that its a valid webhook data package. This fixes that by giving confirmation.

Reference: CV2-4126

## How has this been tested?
Automated tests are on the other side of the transaction

## Have you considered secure coding practices when writing this code?
None relevant for now
