### PR TITLE
CV2-4126 add more explicit flagging to avoid sending stray callback params into callback consumption function

### DIFF
--- a/app/main/controller/presto_controller.py
+++ b/app/main/controller/presto_controller.py
@@ -34,6 +34,7 @@ class PrestoResource(Resource):
             result = similarity.callback_add_item(data.get("body"), model_type)
             if data.get("body", {}).get("raw", {}).get("final_task") == "search":
                 result = similarity.callback_search_item(data.get("body"), model_type)
+                result["is_search_result_callback"] = True
             callback_url = data.get("body", {}).get("raw", {}).get("callback_url", app.config['CHECK_API_HOST']) or app.config['CHECK_API_HOST']
             if data.get("body", {}).get("raw", {}).get("requires_callback"):
                 app.logger.info(f"Sending callback to {callback_url} for {action} for model of {model_type} with body of {result}")

--- a/app/main/controller/similarity_async_controller.py
+++ b/app/main/controller/similarity_async_controller.py
@@ -37,7 +37,7 @@ class AsyncSimilarityResource(Resource):
         if not waiting_for_callback:
             package.pop("created_at", None)
             result = similarity.callback_search_item({"raw": package}, similarity_type)
-            result["is_shortcircuited_callback"] = True
+            result["is_shortcircuited_search_result_callback"] = True
             callback_url = args.get("callback_url", app.config['CHECK_API_HOST']) or app.config['CHECK_API_HOST']
             Webhook.return_webhook(callback_url, "search", similarity_type, result)
         return response

--- a/app/main/lib/shared_models/video_model.py
+++ b/app/main/lib/shared_models/video_model.py
@@ -14,7 +14,6 @@ import tenacity
 import tmkpy
 from sqlalchemy.orm.exc import NoResultFound
 
-from app.main.lib.shared_models.audio_model import AudioModel
 from app.main.lib.shared_models.shared_model import SharedModel
 from app.main.lib.similarity_helpers import get_context_query, drop_context_from_record
 from app.main.lib.helpers import context_matches

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -148,10 +148,10 @@ def callback_search_item(item, similarity_type):
       response = audio_model().search(model_response_package(item.get("raw"), "search"))
       app.logger.info(f"[Alegre Similarity] CallbackSearchItem: [Item {item}, Similarity type: {similarity_type}] Response looks like {response}")
   elif similarity_type == "video":
-      video_response = video_model().search(model_response_package(item.get("raw"), "search"))
+      response = video_model().search(model_response_package(item.get("raw"), "search"))
       # When we search for a video, we need to also search for the audio track of the video against our audio library in case it matches other audio clips.
-      audio_response = audio_model().search(video_model().overload_context_to_denote_content_type(model_response_package(item.get("raw"), "search")))
-      response = merge_audio_and_video_responses(video_response, audio_response)
+      # audio_response = audio_model().search(video_model().overload_context_to_denote_content_type(model_response_package(item.get("raw"), "search")))
+      # response = merge_audio_and_video_responses(video_response, audio_response)
       app.logger.info(f"[Alegre Similarity] CallbackSearchItem: [Item {item}, Similarity type: {similarity_type}] Response looks like {response}")
   elif similarity_type == "image":
       response = async_search_image_on_callback(item)
@@ -209,9 +209,9 @@ def async_get_similar_items(item, similarity_type):
     # Searching with an audio_model() call here is intentional - we need to encode the audio
     # track for all videos to see if we can match them across modes (i.e. this MP3 matches
     # this video's audio track, so they are able to be matched)
-    _, waiting_for_audio_callback = audio_model().async_search(video_model().overload_context_to_denote_content_type(model_response_package(item, "search")), "audio")
+    # _, waiting_for_audio_callback = audio_model().async_search(video_model().overload_context_to_denote_content_type(model_response_package(item, "search")), "audio")
     app.logger.info(f"[Alegre Similarity] [Item {item}, Similarity type: {similarity_type}] response for search was {response}")
-    return response, waiting_for_callback or waiting_for_audio_callback
+    return response, waiting_for_callback# or waiting_for_audio_callback
   elif similarity_type == "image":
     response, waiting_for_callback = async_search_image(item, "image")
     app.logger.info(f"[Alegre Similarity] [Item {item}, Similarity type: {similarity_type}] response for search was {response}")


### PR DESCRIPTION


## Description
New theory is that all webhooks are getting accidentally consumed including ones where its just reporting back that we stored an object. Forcing responses to only be consumed when explicitly flagged as such.
Reference: CV2-4126

## How has this been tested?
Has it been tested locally? Are there automated tests?

## Have you considered secure coding practices when writing this code?
Please list any security concerns that may be relevant.
