### PR TITLE
CV2-4699 add error logging for missing videos

### DIFF
--- a/app/main/lib/shared_models/video_model.py
+++ b/app/main/lib/shared_models/video_model.py
@@ -122,45 +122,49 @@ class VideoModel(SharedModel):
             # a redis key that we've received something from presto.
             result = Presto.blocked_response(response, "video")
             video.hash_value = result.get("body", {}).get("result", {}).get("hash_value")
-        if video and self.tmk_file_exists(video):
-            matches = self.search_by_context(body["context"])
-            default_list = list(np.zeros(len(video.hash_value)))
-            try:
-                l1_scores = np.ndarray.flatten((1-distance.cdist([r.get("hash_value", default_list) or default_list for r in matches], [video.hash_value], 'cosine'))).tolist()
-            except:
-                app.logger.info('L1 scoring failed while running search for video id of '+str(video.id)+' match ids of : '+str([e.get("id") for e in matches]))
-                l1_scores = [0.0 for e in matches]
-            qualified_matches = []
-            for i,match in enumerate(matches):
-                if l1_scores[i] > app.config['VIDEO_MODEL_L1_SCORE']:
-                    qualified_matches.append(match)
-            files = self.get_fullpath_files(qualified_matches, False)
-            try:
-                scores = tmkpy.query(media_crud.tmk_file_path(video.folder, video.filepath),files,1)
-            except Exception as err:
-                ErrorLog.notify(err, {"video_folder": video.folder, "video_filepath": video.filepath, "files": files, "video_id": video.id, "task": task})
-                raise err
-            threshold = float(task.get("threshold", 0.0) or 0.0)
-            results = []
-            for i,score in enumerate(scores):
-                if score > threshold:
-                    results.append({
-                        "context": qualified_matches[i].get("context", {}),
-                        "folder": qualified_matches[i].get("folder"),
-                        "filepath": qualified_matches[i].get("filepath"),
-                        "doc_id": qualified_matches[i].get("doc_id"),
-                        "url": qualified_matches[i].get("url"),
-                        "filename": files[i],
-                        "score": score,
-                        "model": "video"
-                    })
-            if temporary:
-                self.delete(task)
-            limit = task.get("limit")
-            if limit:
-                return {"result": results[:limit]}
+        if video:
+            if self.tmk_file_exists(video):
+                matches = self.search_by_context(body["context"])
+                default_list = list(np.zeros(len(video.hash_value)))
+                try:
+                    l1_scores = np.ndarray.flatten((1-distance.cdist([r.get("hash_value", default_list) or default_list for r in matches], [video.hash_value], 'cosine'))).tolist()
+                except:
+                    app.logger.info('L1 scoring failed while running search for video id of '+str(video.id)+' match ids of : '+str([e.get("id") for e in matches]))
+                    l1_scores = [0.0 for e in matches]
+                qualified_matches = []
+                for i,match in enumerate(matches):
+                    if l1_scores[i] > app.config['VIDEO_MODEL_L1_SCORE']:
+                        qualified_matches.append(match)
+                files = self.get_fullpath_files(qualified_matches, False)
+                try:
+                    scores = tmkpy.query(media_crud.tmk_file_path(video.folder, video.filepath),files,1)
+                except Exception as err:
+                    ErrorLog.notify(err, {"video_folder": video.folder, "video_filepath": video.filepath, "files": files, "video_id": video.id, "task": task})
+                    raise err
+                threshold = float(task.get("threshold", 0.0) or 0.0)
+                results = []
+                for i,score in enumerate(scores):
+                    if score > threshold:
+                        results.append({
+                            "context": qualified_matches[i].get("context", {}),
+                            "folder": qualified_matches[i].get("folder"),
+                            "filepath": qualified_matches[i].get("filepath"),
+                            "doc_id": qualified_matches[i].get("doc_id"),
+                            "url": qualified_matches[i].get("url"),
+                            "filename": files[i],
+                            "score": score,
+                            "model": "video"
+                        })
+                if temporary:
+                    self.delete(task)
+                limit = task.get("limit")
+                if limit:
+                    return {"result": results[:limit]}
+                else:
+                    return {"result": results}
             else:
-                return {"result": results}
+                ErrorLog.notify(Exception("Failed to locate needle for a video!"), {"video_folder": video.folder, "video_filepath": video.filepath, "files": files, "video_id": video.id, "task": task})
+                return {"error": "Video not found for provided task", "task": task}
         else:
             return {"error": "Video not found for provided task", "task": task}
 


### PR DESCRIPTION
## Description
Adds direct logging for needle read failures where we attempt to read a file that doesn't yet exist

Reference: CV2-4699

## How has this been tested?
Not Tested locally yet but directly in line with how we log these types of inform errors other places.

## Have you considered secure coding practices when writing this code?
None
