### PR TITLE
CV2-4752 remove pact from requirements (installed in dockerfiles already)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ oauthlib==3.1.0
 opensearch-py==2.2.0
 opt-einsum==3.2.0
 packaging==21.0
-pact-python==1.4.5
+# pact-python==1.4.5
 # Pillow==8.1.1
 plac==0.9.6
 preshed==2.0.1


### PR DESCRIPTION
## Description
For some reason we're getting issues with our Docker builds - the error is a SHA mismatch when installing pact-python - we already install it directly outside requirements.txt so going to see if just removing from the requirements.txt is sufficient

Reference: CV2-4752

## How has this been tested?
Not yet tested locally

## Have you considered secure coding practices when writing this code?
None