### PR TITLE
CV2-4719 add unique identifier as doc_id at alegre level

### DIFF
--- a/app/main/controller/similarity_async_controller.py
+++ b/app/main/controller/similarity_async_controller.py
@@ -11,6 +11,7 @@ similarity_sync_request = api.model('similarity_sync_request', {
     'text': fields.String(required=False, description='text to be stored or queried for similarity'),
     'url': fields.String(required=False, description='url for item to be stored or queried for similarity'),
     'callback_url': fields.String(required=False, description='callback_url for final search results'),
+    'content_hash': fields.String(required=False, description='Content hash for checking for cached Presto Response'),
     'doc_id': fields.String(required=False, description='text ID to constrain uniqueness'),
     'models': fields.List(required=False, description='similarity models to use: ["elasticsearch"] (pure Elasticsearch, default) or the key name of an active model', cls_or_instance=fields.String),
     'language': fields.String(required=False, description='language code for the analyzer to use during the similarity query (defaults to standard analyzer)'),

--- a/app/main/lib/presto.py
+++ b/app/main/lib/presto.py
@@ -26,6 +26,7 @@ class Presto:
     def send_request(presto_host, model_key, callback_url, message, requires_callback=True):
         data = {
             "callback_url": callback_url,
+            "content_hash": message.get("content_hash", str(uuid.uuid4())),
             "id": message.get("doc_id", str(uuid.uuid4())),
             "url": message.get("url"),
             "text": message.get("text"),

--- a/app/main/lib/presto.py
+++ b/app/main/lib/presto.py
@@ -26,13 +26,16 @@ class Presto:
     def send_request(presto_host, model_key, callback_url, message, requires_callback=True):
         data = {
             "callback_url": callback_url,
-            "content_hash": message.get("content_hash", str(uuid.uuid4())),
-            "id": message.get("doc_id", str(uuid.uuid4())),
+            "content_hash": message.get("content_hash"),
             "url": message.get("url"),
             "text": message.get("text"),
             "raw": message,
             "requires_callback": requires_callback
         }
+        if message.get("doc_id"):
+            data["id"] = message.get("doc_id")
+        else:
+            data["id"] = str(uuid.uuid4())
         headers = {"Content-Type": "application/json"}
         json_data = json.dumps(data, default=safe_serializer)
         return requests.post(f"{presto_host}/process_item/{model_key}", data=json_data, headers=headers)

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -64,7 +64,7 @@ def get_body_for_text_document(params, mode):
       params['content'] = None
 
     if mode == 'store':
-      allow_list = set(['language', 'content', 'created_at', 'models', 'context', 'callback_url'])
+      allow_list = set(['language', 'content', 'created_at', 'models', 'context', 'callback_url', 'content_hash'])
       keys_to_remove = params.keys() - allow_list
       app.logger.info(
         f"[Alegre Similarity] get_body_for_text_document:running in `store' mode. Removing {keys_to_remove}")
@@ -85,6 +85,7 @@ def model_response_package(item, command):
     "limit": item.get("limit", DEFAULT_SEARCH_LIMIT) or DEFAULT_SEARCH_LIMIT,
     "url": item.get("url"),
     "callback_url": item.get("callback_url"),
+    "content_hash": item.get("content_hash"),
     "doc_id": item.get("doc_id"),
     "context": item.get("context", {}),
     "created_at": item.get("created_at"),


### PR DESCRIPTION
## Description
Plumbs content_hash from check-api to presto request - not much exciting happening at this level

Reference: CV2-4719

## How has this been tested?
First changing this without updating tests to see what breaks, then fix tests, then integration tests locally

## Have you considered secure coding practices when writing this code?
None relevant here
