### PR TITLE
CV2-4856 alter query body to check for vectors before querying against them

### DIFF
--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -108,23 +108,15 @@ def get_vector_model_base_conditions(search_params, model_key, threshold):
                     'bool': {
                         'must': [
                             {
-                                'match': {
-                                    'model_' + str(model_key): {
-                                        'query': "1",
-                                    }
+                                'exists': {
+                                    'field': 'vector_'+str(model_key)
                                 }
                             }
                         ]
                     }
                 },
                 'script': {
-                    'source': """
-                        if (!doc.containsKey('vector_""" + str(model_key) + """') || doc['vector_""" + str(model_key) + """'].size() == 0) { 
-                            return 0; 
-                        } else { 
-                            return cosineSimilarity(params.query_vector, doc[params.field]) + 1.0; 
-                        }
-                    """,
+                    'source': "cosineSimilarity(params.query_vector, doc[params.field]) + 1.0",
                     'params': {
                         'field': "vector_" + str(model_key),
                         'query_vector': vector

--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -90,42 +90,49 @@ def get_elasticsearch_base_conditions(search_params, clause_count, threshold):
     return conditions
 
 def get_vector_model_base_conditions(search_params, model_key, threshold):
-  if "vector" in search_params:
-    vector = search_params["vector"]
-  elif model_key[:len(PREFIX_OPENAI)] == PREFIX_OPENAI:
-    vector = retrieve_openai_embeddings(search_params['content'], model_key)
-    if vector == None:
-       return None
-  else:
-    model = SharedModel.get_client(model_key)
-    vector = model.get_shared_model_response(search_params['content'])
-  return {
-      'query': {
-          'script_score': {
-              'min_score': float(threshold)+1,
-              'query': {
-                  'bool': {
-                      'must': [
-                          {
-                              'match': {
-                                  'model_'+str(model_key): {
-                                    'query': "1",
-                                  }
-                              }
-                          }
-                      ]
-                  }
-              },
-              'script': {
-                  'source': "cosineSimilarity(params.query_vector, doc[params.field]) + 1.0",
-                  'params': {
-                      'field': "vector_"+str(model_key),
-                      'query_vector': vector
-                  }
-              }
-          }
-      }
-  }
+    if "vector" in search_params:
+        vector = search_params["vector"]
+    elif model_key[:len(PREFIX_OPENAI)] == PREFIX_OPENAI:
+        vector = retrieve_openai_embeddings(search_params['content'], model_key)
+        if vector is None:
+            return None
+    else:
+        model = SharedModel.get_client(model_key)
+        vector = model.get_shared_model_response(search_params['content'])
+
+    return {
+        'query': {
+            'script_score': {
+                'min_score': float(threshold) + 1,
+                'query': {
+                    'bool': {
+                        'must': [
+                            {
+                                'match': {
+                                    'model_' + str(model_key): {
+                                        'query': "1",
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                'script': {
+                    'source': """
+                        if (!doc.containsKey('vector_""" + str(model_key) + """') || doc['vector_""" + str(model_key) + """'].size() == 0) { 
+                            return 0; 
+                        } else { 
+                            return cosineSimilarity(params.query_vector, doc[params.field]) + 1.0; 
+                        }
+                    """,
+                    'params': {
+                        'field': "vector_" + str(model_key),
+                        'query_vector': vector
+                    }
+                }
+            }
+        }
+    }
 
 def insert_model_into_response(hits, model_key):
     for hit in hits:


### PR DESCRIPTION
## Description
Some queries on opensearch fail because we're querying on fields that don't exist on documents. This only happens on QA currently, but could happen anywhere because of some potential failure in storing documents correctly. We should be robust against those potential failures.

Reference: CV2-4856

## How has this been tested?
Works on QA servers when testing these changes directly

## Have you considered secure coding practices when writing this code?
None
