### PR TITLE
CV2-4790 fix broken error log due to missing file, surface s3 errors to sentry

### DIFF
--- a/app/main/lib/s3_client.py
+++ b/app/main/lib/s3_client.py
@@ -3,6 +3,8 @@ from botocore.client import Config
 
 from flask import current_app as app
 
+from app.main.lib.error_log import ErrorLog
+
 MINIO_HOST = "minio:9000"
 def download_file_from_s3(bucket: str, filename: str, local_path: str):
     """
@@ -32,6 +34,7 @@ def download_file_from_s3(bucket: str, filename: str, local_path: str):
         s3_client.download_file(bucket, tmk_file, local_path)
         app.logger.info(f'Successfully downloaded file {tmk_file} from S3 bucket.')
     except Exception as e:
+        ErrorLog.notify(e, {"bucket": bucket, "filename": filename, "local_path": local_path, "tmk_file": tmk_file})
         app.logger.error(f'Failed to download file {tmk_file} from S3 bucket: {e}')
         raise e
 

--- a/app/main/lib/shared_models/video_model.py
+++ b/app/main/lib/shared_models/video_model.py
@@ -163,7 +163,7 @@ class VideoModel(SharedModel):
                 else:
                     return {"result": results}
             else:
-                ErrorLog.notify(Exception("Failed to locate needle for a video!"), {"video_folder": video.folder, "video_filepath": video.filepath, "files": files, "video_id": video.id, "task": task})
+                ErrorLog.notify(Exception("Failed to locate needle for a video!"), {"video_folder": video.folder, "video_filepath": video.filepath, "video_id": video.id, "task": task})
                 return {"error": "Video not found for provided task", "task": task}
         else:
             return {"error": "Video not found for provided task", "task": task}


### PR DESCRIPTION
## Description
Right now we hit an error where `files` isn't defined when we try to log the needle error to sentry, and we don't log failures to download the files from S3 directly to sentry. Let's resolve that to make easier the job of surfacing whatever the needle error is.

Reference: CV2-4790

## How has this been tested?
No tests on this yet - may need to change a unit test or two.

## Have you considered secure coding practices when writing this code?
None
