### PR TITLE
CV2-4790 refactor check for file presence, add check for non-zero file

### DIFF
--- a/app/main/lib/shared_models/video_model.py
+++ b/app/main/lib/shared_models/video_model.py
@@ -123,53 +123,54 @@ class VideoModel(SharedModel):
             result = Presto.blocked_response(response, "video")
             video.hash_value = result.get("body", {}).get("result", {}).get("hash_value")
         if video:
-            if self.tmk_file_exists(video):
-                matches = self.search_by_context(body["context"])
-                default_list = list(np.zeros(len(video.hash_value)))
-                try:
-                    l1_scores = np.ndarray.flatten((1-distance.cdist([r.get("hash_value", default_list) or default_list for r in matches], [video.hash_value], 'cosine'))).tolist()
-                except:
-                    app.logger.info('L1 scoring failed while running search for video id of '+str(video.id)+' match ids of : '+str([e.get("id") for e in matches]))
-                    l1_scores = [0.0 for e in matches]
-                qualified_matches = []
-                for i,match in enumerate(matches):
-                    if l1_scores[i] > app.config['VIDEO_MODEL_L1_SCORE']:
-                        qualified_matches.append(match)
-                files = self.get_fullpath_files(qualified_matches, False)
-                try:
+            matches = self.search_by_context(body["context"])
+            default_list = list(np.zeros(len(video.hash_value)))
+            try:
+                l1_scores = np.ndarray.flatten((1-distance.cdist([r.get("hash_value", default_list) or default_list for r in matches], [video.hash_value], 'cosine'))).tolist()
+            except:
+                app.logger.info('L1 scoring failed while running search for video id of '+str(video.id)+' match ids of : '+str([e.get("id") for e in matches]))
+                l1_scores = [0.0 for e in matches]
+            qualified_matches = []
+            for i,match in enumerate(matches):
+                if l1_scores[i] > app.config['VIDEO_MODEL_L1_SCORE']:
+                    qualified_matches.append(match)
+            files = self.get_fullpath_files(qualified_matches, False)
+            try:
+                if self.tmk_file_exists(video):
                     scores = tmkpy.query(media_crud.tmk_file_path(video.folder, video.filepath),files,1)
-                except Exception as err:
-                    ErrorLog.notify(err, {"video_folder": video.folder, "video_filepath": video.filepath, "files": files, "video_id": video.id, "task": task})
-                    raise err
-                threshold = float(task.get("threshold", 0.0) or 0.0)
-                results = []
-                for i,score in enumerate(scores):
-                    if score > threshold:
-                        results.append({
-                            "context": qualified_matches[i].get("context", {}),
-                            "folder": qualified_matches[i].get("folder"),
-                            "filepath": qualified_matches[i].get("filepath"),
-                            "doc_id": qualified_matches[i].get("doc_id"),
-                            "url": qualified_matches[i].get("url"),
-                            "filename": files[i],
-                            "score": score,
-                            "model": "video"
-                        })
-                if temporary:
-                    self.delete(task)
-                limit = task.get("limit")
-                if limit:
-                    return {"result": results[:limit]}
                 else:
-                    return {"result": results}
+                    ErrorLog.notify(Exception("Failed to locate needle for a video!"), {"video_folder": video.folder, "video_filepath": video.filepath, "video_id": video.id, "task": task})
+                    return {"error": "Video not found for provided task", "task": task}
+            except Exception as err:
+                ErrorLog.notify(err, {"video_folder": video.folder, "video_filepath": video.filepath, "files": files, "video_id": video.id, "task": task})
+                raise err
+            threshold = float(task.get("threshold", 0.0) or 0.0)
+            results = []
+            for i,score in enumerate(scores):
+                if score > threshold:
+                    results.append({
+                        "context": qualified_matches[i].get("context", {}),
+                        "folder": qualified_matches[i].get("folder"),
+                        "filepath": qualified_matches[i].get("filepath"),
+                        "doc_id": qualified_matches[i].get("doc_id"),
+                        "url": qualified_matches[i].get("url"),
+                        "filename": files[i],
+                        "score": score,
+                        "model": "video"
+                    })
+            if temporary:
+                self.delete(task)
+            limit = task.get("limit")
+            if limit:
+                return {"result": results[:limit]}
             else:
-                ErrorLog.notify(Exception("Failed to locate needle for a video!"), {"video_folder": video.folder, "video_filepath": video.filepath, "video_id": video.id, "task": task})
-                return {"error": "Video not found for provided task", "task": task}
+                return {"result": results}
         else:
             return {"error": "Video not found for provided task", "task": task}
 
     def tmk_file_exists(self, video):
-        return os.path.exists(media_crud.tmk_file_path(video.folder, video.filepath))
+        file_path = media_crud.tmk_file_path(video.folder, video.filepath)
+        return os.path.exists(file_path) and os.path.getsize(file_path) > 0
 
     def tmk_program_name(self):
         return "AlegreVideoEncoder"


### PR DESCRIPTION
## Description
In an ongoing attempt to catch the exact situation where this race condition happens, I'm doing two things here - first, move the file check to the exact moment before we need the file to try to mitigate any timing-based issues as much as possible, and second, add a constraint that the file also has to be actually filled with content, not just touch'ed or existing. Both of these have plausible theories for why they'd resolve this, potentially, but I don't personally think either are particularly likely. Again, it still looks like these are temporary items that are having these issues.

The theory for the temporary file is if we request an item be encoded twice (once for confirmed and another time for suggested or confirmed), and the item is a temporary item, then we could get into a situation where one of the workers deletes the file while the other worker is running the check. The theory for the file case is that perhaps the file is caught in some interstitial state (again unlikely, but maybe possible) and thus not actually ready for access.

If we see the issue less often with this patch my guess would be that we're likely running into the double-encoding case. A move for resolving it would be to potentially defer the deletion for a few minutes rather than deleting immediately?

Reference: CV2-4790

## How has this been tested?
Tested both tweaks against repl, should be fairly straightforward

## Have you considered secure coding practices when writing this code?
None