### PR TITLE
CV2-5011 refactors for making alegre dual purpose on text encoding

### DIFF
--- a/app/main/controller/presto_controller.py
+++ b/app/main/controller/presto_controller.py
@@ -32,9 +32,10 @@ class PrestoResource(Resource):
             result = similarity.callback_add_item(data.get("body"), model_type)
             if data.get("body", {}).get("raw", {}).get("final_task") == "search":
                 result = similarity.callback_search_item(data.get("body"), model_type)
-                result["is_search_result_callback"] = True
+                if result:
+                    result["is_search_result_callback"] = True
             callback_url = data.get("body", {}).get("raw", {}).get("callback_url", app.config['CHECK_API_HOST']) or app.config['CHECK_API_HOST']
-            if data.get("body", {}).get("raw", {}).get("requires_callback"):
+            if result and data.get("body", {}).get("raw", {}).get("requires_callback"):
                 app.logger.info(f"Sending callback to {callback_url} for {action} for model of {model_type} with body of {result}")
                 Webhook.return_webhook(callback_url, action, model_type, result)
             output = {"action": action, "model_type": model_type, "data": result}

--- a/app/main/lib/elastic_crud.py
+++ b/app/main/lib/elastic_crud.py
@@ -86,7 +86,7 @@ def parse_task_search(task):
     # alternatively, the "body" is just the entire dictionary.
     if "body" in task:
         body = task.get("body", {})
-        threshold = task.get("raw", {}).get('threshold', 0.0)
+        threshold = body.get("raw", {}).get('threshold', 0.0)
         limit = body.get("raw", {}).get("limit")
         if not body.get("raw"):
             body["raw"] = {}

--- a/app/main/lib/elastic_crud.py
+++ b/app/main/lib/elastic_crud.py
@@ -57,7 +57,7 @@ def get_blocked_presto_response(task, model, modality):
             if model_key != "elasticsearch" and not obj.get('model_'+model_key):
                 response = get_presto_request_response(model_key, callback_url, obj)
                 blocked_results.append(Presto.blocked_response(response, modality))
-        # Warning: this is a blocking hold to wait until we get a response in 
+        # Warning: this is a blocking hold to wait until we get a response in
         # a redis key that we've received something from presto.
         return obj, temporary, get_context_for_search(task), blocked_results[-1]
     else:
@@ -66,7 +66,7 @@ def get_blocked_presto_response(task, model, modality):
 def get_async_presto_response(task, model, modality):
     app.logger.error(f"get_async_presto_response: {task} {model} {modality}")
     obj, _ = get_object(task, model)
-    callback_url =  Presto.add_item_callback_url(app.config['ALEGRE_HOST'], modality)
+    callback_url = Presto.add_item_callback_url(app.config['ALEGRE_HOST'], modality)
     if task.get("doc_id") is None:
         task["doc_id"] = str(uuid.uuid4())
     task["final_task"] = "search"

--- a/app/main/lib/elastic_crud.py
+++ b/app/main/lib/elastic_crud.py
@@ -47,7 +47,7 @@ def requires_encoding(obj):
 def get_blocked_presto_response(task, model, modality):
     if task.get("doc_id") is None:
         task["doc_id"] = str(uuid.uuid4())
-    obj, _ = get_object(task, model)
+    obj, temporary = get_object(task, model)
     doc_id = obj["doc_id"]
     callback_url =  Presto.add_item_callback_url(app.config['ALEGRE_HOST'], modality)
     app.logger.info(f"Object for {task} of model {model} with id of {doc_id} has requires_encoding value of {requires_encoding(obj)}")
@@ -65,7 +65,7 @@ def get_blocked_presto_response(task, model, modality):
 
 def get_async_presto_response(task, model, modality):
     app.logger.error(f"get_async_presto_response: {task} {model} {modality}")
-    obj, temporary = get_object(task, model)
+    obj, _ = get_object(task, model)
     callback_url =  Presto.add_item_callback_url(app.config['ALEGRE_HOST'], modality)
     if task.get("doc_id") is None:
         task["doc_id"] = str(uuid.uuid4())

--- a/app/main/lib/elastic_crud.py
+++ b/app/main/lib/elastic_crud.py
@@ -11,7 +11,7 @@ def _after_log(retry_state):
 def get_object_by_doc_id(doc_id):
     return get_by_doc_id(doc_id)
 
-def get_object(task, model):
+def get_object(task, _):
     doc_id = task.get("doc_id", None)
     language = task.get("language", None)
     context = task.get("context", {})
@@ -49,7 +49,7 @@ def get_blocked_presto_response(task, model, modality):
         task["doc_id"] = str(uuid.uuid4())
     obj, temporary = get_object(task, model)
     doc_id = obj["doc_id"]
-    callback_url =  Presto.add_item_callback_url(app.config['ALEGRE_HOST'], modality)
+    callback_url = Presto.add_item_callback_url(app.config['ALEGRE_HOST'], modality)
     app.logger.info(f"Object for {task} of model {model} with id of {doc_id} has requires_encoding value of {requires_encoding(obj)}")
     if requires_encoding(obj):
         blocked_results = []

--- a/app/main/lib/elastic_crud.py
+++ b/app/main/lib/elastic_crud.py
@@ -15,8 +15,13 @@ def get_object(task, _):
     doc_id = task.get("doc_id", None)
     language = task.get("language", None)
     context = task.get("context", {})
+    if not task.get("contexts"):
+        if not isinstance(task.get("contexts"), list):
+            task["contexts"] = [task["contexts"]]
+        else:
+            task["contexts"] = []
     if context:
-        task["contexts"] = [context]
+        task["contexts"].append(context)
     store_document(task, doc_id, language)
     if task.get("content") and not task.get("text"):
         task["text"] = task["content"]

--- a/app/main/lib/elastic_crud.py
+++ b/app/main/lib/elastic_crud.py
@@ -3,10 +3,10 @@ import uuid
 import json
 from flask import current_app as app
 from app.main.lib.presto import Presto, PRESTO_MODEL_MAP
-from app.main.lib.elasticsearch import store_document, delete_document, get_by_doc_id
+from app.main.lib.elasticsearch import store_document, get_by_doc_id
 
 def _after_log(retry_state):
-  app.logger.debug("Retrying image similarity...")
+    app.logger.debug("Retrying image similarity...")
 
 def get_object_by_doc_id(doc_id):
     return get_by_doc_id(doc_id)
@@ -16,7 +16,7 @@ def get_object(task, model):
     language = task.get("language", None)
     context = task.get("context", {})
     if context:
-      task["contexts"] = [context]
+        task["contexts"] = [context]
     store_document(task, doc_id, language)
     if task.get("content") and not task.get("text"):
         task["text"] = task["content"]
@@ -47,7 +47,7 @@ def requires_encoding(obj):
 def get_blocked_presto_response(task, model, modality):
     if task.get("doc_id") is None:
         task["doc_id"] = str(uuid.uuid4())
-    obj, temporary = get_object(task, model)
+    obj, _ = get_object(task, model)
     doc_id = obj["doc_id"]
     callback_url =  Presto.add_item_callback_url(app.config['ALEGRE_HOST'], modality)
     app.logger.info(f"Object for {task} of model {model} with id of {doc_id} has requires_encoding value of {requires_encoding(obj)}")

--- a/app/main/lib/elastic_crud.py
+++ b/app/main/lib/elastic_crud.py
@@ -1,0 +1,113 @@
+import pathlib
+import os
+import copy
+import uuid
+import urllib.error
+import json
+import tenacity
+from flask import current_app as app
+from app.main.lib.presto import Presto, PRESTO_MODEL_MAP
+from app.main.lib.similarity_helpers import drop_context_from_record
+from app.main.lib.helpers import merge_dict_lists
+from app.main.lib import media_crud
+from app.main.lib.elasticsearch import generate_matches, truncate_query, store_document, delete_document, update_or_create_document, get_by_doc_id
+
+def _after_log(retry_state):
+  app.logger.debug("Retrying image similarity...")
+
+def delete(task, model):
+    if task.get("doc_id"):
+        deleted = delete_document(task.get("doc_id"), task.get("context"), quiet)
+        return {"requested": task, "result": {"deleted": deleted}}
+    else:
+        return {"requested": task, "result": {"deleted": False}}
+
+def get_object_by_doc_id(doc_id):
+    return get_by_doc_id(doc_id)
+
+def get_object(task, model):
+    doc_id = task.get("doc_id", None)
+    language = task.get("language", None)
+    context = task.get("context", {})
+    if context:
+      task["contexts"] = [context]
+    store_document(task, doc_id, language)
+    if task.get("content") and not task.get("text"):
+        task["text"] = task["content"]
+    return task, False
+
+def get_context_for_search(task):
+    context = {}
+    dup = copy.deepcopy(task)
+    if dup.get('context'):
+        context = dup.get('context')
+    if dup.get("match_across_content_types"):
+        context.pop("content_type", None)
+    return context
+
+def get_presto_request_response(modality, callback_url, task):
+    response = json.loads(Presto.send_request(app.config['PRESTO_HOST'], PRESTO_MODEL_MAP[modality], callback_url, task, False).text)
+    assert response["message"] == "Message pushed successfully", f"Bad response message for {modality}, {callback_url}, {task} - response was {response}"
+    assert response["queue"] in PRESTO_MODEL_MAP.values(), f"Unknown queue for {modality}, {callback_url}, {task} - response was {response}"
+    assert isinstance(response["body"], dict), f"Bad body for {modality}, {callback_url}, {task} - response was {response}"
+    return response
+
+def requires_encoding(obj):
+    for model_key in obj.get("models", []):
+        if not obj.get('model_'+model_key):
+            return True
+    return False
+
+def get_blocked_presto_response(task, model, modality):
+    if task.get("doc_id") is None:
+        task["doc_id"] = str(uuid.uuid4())
+    obj, temporary = get_object(task, model)
+    doc_id = obj["doc_id"]
+    callback_url =  Presto.add_item_callback_url(app.config['ALEGRE_HOST'], modality)
+    app.logger.info(f"Object for {task} of model {model} with id of {doc_id} has requires_encoding value of {requires_encoding(obj)}")
+    if requires_encoding(obj):
+        blocked_results = []
+        for model_key in obj.pop("models", []):
+            if model_key != "elasticsearch" and not obj.get('model_'+model_key):
+                response = get_presto_request_response(model_key, callback_url, obj)
+                blocked_results.append(Presto.blocked_response(response, modality))
+        # Warning: this is a blocking hold to wait until we get a response in 
+        # a redis key that we've received something from presto.
+        return obj, temporary, get_context_for_search(task), blocked_results[-1]
+    else:
+        return obj, temporary, get_context_for_search(task), {"body": obj}
+
+def get_async_presto_response(task, model, modality):
+    app.logger.error(f"get_async_presto_response: {task} {model} {modality}")
+    obj, temporary = get_object(task, model)
+    callback_url =  Presto.add_item_callback_url(app.config['ALEGRE_HOST'], modality)
+    if task.get("doc_id") is None:
+        task["doc_id"] = str(uuid.uuid4())
+    task["final_task"] = "search"
+    if requires_encoding(obj):
+        responses = []
+        for model_key in obj.get("models", []):
+            if model_key != "elasticsearch" and not obj.get('model_'+model_key):
+                task["model"] = model_key
+                responses.append(get_presto_request_response(model_key, callback_url, task))
+        return responses, True
+    else:
+        return {"message": "Already encoded - passing on to search"}, False
+
+def parse_task_search(task):
+    # here, we have to unpack the task contents to pull out the body,
+    # which may be embedded in a body key in the dict if its coming from a presto callback.
+    # alternatively, the "body" is just the entire dictionary.
+    if "body" in task:
+        body = task.get("body", {})
+        threshold = task.get("raw", {}).get('threshold', 0.0)
+        limit = body.get("raw", {}).get("limit")
+        if not body.get("raw"):
+            body["raw"] = {}
+        body["hash_value"] = body.get("result", {}).get("hash_value")
+        body["context"] = body.get("context", body.get("raw", {}).get("context"))
+    else:
+        body = task
+        threshold = body.get('threshold', 0.0)
+        limit = body.get("limit")
+    return body, threshold, limit

--- a/app/main/lib/elastic_crud.py
+++ b/app/main/lib/elastic_crud.py
@@ -1,26 +1,12 @@
-import pathlib
-import os
 import copy
 import uuid
-import urllib.error
 import json
-import tenacity
 from flask import current_app as app
 from app.main.lib.presto import Presto, PRESTO_MODEL_MAP
-from app.main.lib.similarity_helpers import drop_context_from_record
-from app.main.lib.helpers import merge_dict_lists
-from app.main.lib import media_crud
-from app.main.lib.elasticsearch import generate_matches, truncate_query, store_document, delete_document, update_or_create_document, get_by_doc_id
+from app.main.lib.elasticsearch import store_document, delete_document, get_by_doc_id
 
 def _after_log(retry_state):
   app.logger.debug("Retrying image similarity...")
-
-def delete(task, model):
-    if task.get("doc_id"):
-        deleted = delete_document(task.get("doc_id"), task.get("context"), quiet)
-        return {"requested": task, "result": {"deleted": deleted}}
-    else:
-        return {"requested": task, "result": {"deleted": False}}
 
 def get_object_by_doc_id(doc_id):
     return get_by_doc_id(doc_id)

--- a/app/main/lib/elastic_crud.py
+++ b/app/main/lib/elastic_crud.py
@@ -15,11 +15,8 @@ def get_object(task, _):
     doc_id = task.get("doc_id", None)
     language = task.get("language", None)
     context = task.get("context", {})
-    if not task.get("contexts"):
-        if not isinstance(task.get("contexts"), list):
-            task["contexts"] = [task["contexts"]]
-        else:
-            task["contexts"] = []
+    if "contexts" not in task or not isinstance(task["contexts"], list):
+        task["contexts"] = [task["contexts"]] if "contexts" in task else []
     if context:
         task["contexts"].append(context)
     store_document(task, doc_id, language)

--- a/app/main/lib/elasticsearch.py
+++ b/app/main/lib/elasticsearch.py
@@ -112,7 +112,7 @@ def get_by_doc_id(doc_id):
     return response['_source']
 
 def store_document(body, doc_id, language=None):
-    for field in ["per_model_threshold", "threshold", "model", "confirmed", "limit", "requires_callback", "context"]:
+    for field in ["per_model_threshold", "threshold", "model", "confirmed", "limit", "requires_callback"]:
         body.pop(field, None)
     indices = [app.config['ELASTICSEARCH_SIMILARITY']]
     # 'auto' indicates we should try to guess the appropriate language

--- a/app/main/lib/elasticsearch.py
+++ b/app/main/lib/elasticsearch.py
@@ -106,7 +106,14 @@ def update_or_create_document(body, doc_id, index):
       )
   return result
 
+def get_by_doc_id(doc_id):
+    es = OpenSearch(app.config['ELASTICSEARCH_URL'])
+    response = es.get(index=app.config['ELASTICSEARCH_SIMILARITY'], id=doc_id)
+    return response['_source']
+
 def store_document(body, doc_id, language=None):
+    for field in ["per_model_threshold", "threshold", "model", "confirmed", "limit", "requires_callback", "context"]:
+        body.pop(field, None)
     indices = [app.config['ELASTICSEARCH_SIMILARITY']]
     # 'auto' indicates we should try to guess the appropriate language
     if language == 'auto':
@@ -124,7 +131,7 @@ def store_document(body, doc_id, language=None):
     for index in indices:
       index_result = update_or_create_document(body, doc_id, index)
       results.append(index_result)
-      if index_result['result'] not in ['created', 'updated']:
+      if index_result['result'] not in ['created', 'updated', 'noop']:
           app.logger.warning('Problem adding document to ES index for language {0}: {1}'.format(language, index_result))
     result = results[0]
     success = False

--- a/app/main/lib/helpers.py
+++ b/app/main/lib/helpers.py
@@ -1,3 +1,19 @@
+def merge_dict_lists(list1, list2):
+    """
+    Merge two lists of dictionaries, ensuring all unique dictionaries are present in the final result.
+    
+    :param list1: First list of dictionaries.
+    :param list2: Second list of dictionaries.
+    :return: Merged list of unique dictionaries.
+    """
+    def to_hashable(d):
+        return tuple((k, tuple(v) if isinstance(v, list) else v) for k, v in sorted(d.items()))
+    def to_dict(t):
+        return {k: list(v) if isinstance(v, tuple) else v for k, v in t}
+    unique = set(to_hashable(d) for d in list1 + list2)
+    return [to_dict(d) for d in unique]
+
+
 def context_matches(query_context, item_context):
   """
     Check a pair of contexts to determine if they match - first pass is

--- a/app/main/lib/image_similarity.py
+++ b/app/main/lib/image_similarity.py
@@ -62,7 +62,7 @@ def add_image(save_params):
     db.session.rollback()
     raise e
 
-def callback_add(task):
+def callback_add_image(task):
     return media_crud.add(task, ImageModel, ["pdq", "phash"])[0]
 
 def search_image(image, model, limit, threshold, task, hash_value, context, temporary):

--- a/app/main/lib/media_crud.py
+++ b/app/main/lib/media_crud.py
@@ -12,22 +12,8 @@ from flask import current_app as app
 from app.main import db
 from app.main.model.video import Video
 from app.main.lib.presto import Presto, PRESTO_MODEL_MAP
+from app.main.lib.helpers import merge_dict_lists
 from app.main.lib.similarity_helpers import drop_context_from_record
-
-def merge_dict_lists(list1, list2):
-    """
-    Merge two lists of dictionaries, ensuring all unique dictionaries are present in the final result.
-    
-    :param list1: First list of dictionaries.
-    :param list2: Second list of dictionaries.
-    :return: Merged list of unique dictionaries.
-    """
-    def to_hashable(d):
-        return tuple((k, tuple(v) if isinstance(v, list) else v) for k, v in sorted(d.items()))
-    def to_dict(t):
-        return {k: list(v) if isinstance(v, tuple) else v for k, v in t}
-    unique = set(to_hashable(d) for d in list1 + list2)
-    return [to_dict(d) for d in unique]
 
 def _after_log(retry_state):
   app.logger.debug("Retrying image similarity...")

--- a/app/main/lib/presto.py
+++ b/app/main/lib/presto.py
@@ -9,9 +9,13 @@ PRESTO_MODEL_MAP = {
     "video": "video__Model",
     "image": "image__Model",
     "meantokens": "mean_tokens__Model",
-    "indiansbert": "indian_sbert__Mode",
+    "indiansbert": "indian_sbert__Model",
     "mdebertav3filipino": "fptg__Model",
+    "xlm-r-bert-base-nli-stsb-mean-tokens": "mean_tokens__Model",
+    "indian-sbert": "indian_sbert__Model",
+    "paraphrase-filipino-mpnet-base-v2": "fptg__Model",
 }
+
 
 class Presto:
     @staticmethod

--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -40,7 +40,7 @@ def fill_in_openai_embeddings(document):
         if model_key != "elasticsearch" and model_key[:len(PREFIX_OPENAI)] == PREFIX_OPENAI:
             document['vector_'+model_key] = retrieve_openai_embeddings(document['content'], model_key)
             document['model_'+model_key] = 1
-    store_document(document, document["id"], document["language"])
+    store_document(document, document["doc_id"], document["language"])
 
 def async_search_text_on_callback(task):
     app.logger.info(f"async_search_text_on_callback(task) is {task}")

--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -90,6 +90,8 @@ def get_model_and_threshold(search_params):
   if 'per_model_threshold' in search_params and isinstance(search_params['per_model_threshold'], list) and [e for e in search_params['per_model_threshold'] if e["model"] == model_key]:
       threshold = [e for e in search_params['per_model_threshold'] if e["model"] == model_key][0]["value"]
   if threshold is None:
+      app.logger.error(
+          f"[Alegre Similarity] get_model_and_threshold - no threshold was specified, backing down to default of 0.9 - search_params is {search_params}")
       threshold = 0.9
   return model_key, threshold
 

--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -123,19 +123,16 @@ def get_elasticsearch_base_conditions(search_params, clause_count, threshold):
             conditions[0]['match']['content']['fuzziness'] = 'AUTO'
     return conditions
 
-def get_vector_model_base_conditions(search_params, model_key, threshold, vector_for_search=None):
-    if vector_for_search:
-        vector = vector_for_search
-    else:
-        if "vector" in search_params:
-            vector = search_params["vector"]
-        elif model_key[:len(PREFIX_OPENAI)] == PREFIX_OPENAI:
-            vector = retrieve_openai_embeddings(search_params['content'], model_key)
-            if vector is None:
-                return None
-        else:
-            model = SharedModel.get_client(model_key)
-            vector = model.get_shared_model_response(search_params['content'])
+def get_vector_model_base_conditions(search_params, model_key, threshold, vector=None):
+    if "vector" in search_params:
+        vector = search_params["vector"]
+    elif model_key[:len(PREFIX_OPENAI)] == PREFIX_OPENAI:
+        vector = retrieve_openai_embeddings(search_params['content'], model_key)
+        if vector is None:
+            return None
+    elif not vector:
+        model = SharedModel.get_client(model_key)
+        vector = model.get_shared_model_response(search_params['content'])
     return {
         'query': {
             'script_score': {

--- a/app/test/test_elastic_crud.py
+++ b/app/test/test_elastic_crud.py
@@ -58,7 +58,7 @@ class TestElasticCrud(unittest.TestCase):
         }))
 
         task = {'doc_id': '123', 'content': 'test content'}
-        modality = 'test_modality'
+        modality = 'meantokens'
         callback_url = 'http://example.com/callback'
 
         result = get_presto_request_response(modality, callback_url, task)
@@ -84,7 +84,7 @@ class TestElasticCrud(unittest.TestCase):
         
         task = {'url': 'http://example.com', 'context': {'foo': 'bar'}}
         model = MagicMock()
-        modality = 'test_modality'
+        modality = 'meantokens'
         
         result = get_blocked_presto_response(task, model, modality)
         self.assertIsNotNone(result)

--- a/app/test/test_elastic_crud.py
+++ b/app/test/test_elastic_crud.py
@@ -1,0 +1,139 @@
+from unittest.mock import patch, MagicMock
+from flask import current_app as app
+from opensearchpy import OpenSearch, TransportError
+from app.main.lib.elastic_crud import save, delete, add, get_by_doc_id_or_url, get_object
+import unittest
+import json
+
+
+class TestElasticCrud(unittest.TestCase):
+    @patch('app.main.lib.elastic_crud.OpenSearch')
+    def test_save_existing_object(self, mock_opensearch):
+        # Mock existing document in Elasticsearch
+        mock_es = mock_opensearch.return_value
+        mock_es.search.return_value = {'hits': {'hits': [{'id': '1', '_source': {'url': 'http://example.com', 'context': [{'foo': 'bar'}, {'baz': 'bat'}]}}]}}
+        mock_es.index.return_value = {'result': 'updated'}
+
+        # Calling save function with an object having the same URL
+        obj = {'url': 'http://example.com', 'context': [{'foo': 'bar'}, {'baz': 'bat'}]}
+        result = save(obj)
+
+        # Check if existing object is updated in Elasticsearch
+        self.assertTrue(result['result'] == 'updated')
+
+    @patch('app.main.lib.elastic_crud.OpenSearch')
+    def test_save_new_object(self, mock_opensearch):
+        # Mock no existing document in Elasticsearch
+        mock_es = mock_opensearch.return_value
+        mock_es.search.return_value = {'hits': {'hits': []}}
+        mock_es.index.return_value = {'result': 'created'}
+
+        # Calling save function with a new object
+        obj = {'url': 'http://newexample.com', 'context': 'new_context'}
+        result = save(obj)
+
+        # Check if new object is added in Elasticsearch
+        self.assertTrue(result['result'] == 'created')
+
+    @patch('app.main.lib.elastic_crud.OpenSearch')
+    def test_save_exception_handling(self, mock_opensearch):
+        # Mocking an exception during the save process
+        mock_es = mock_opensearch.return_value
+        mock_es.index.side_effect = TransportError(500, 'Internal Server Error')
+
+        obj = {'url': 'http://exceptionexample.com', 'context': 'new_context'}
+
+        # Expecting an exception to be raised
+        with self.assertRaises(TransportError):
+            save(obj)
+
+    @patch('app.main.lib.elastic_crud.OpenSearch')
+    def test_delete(self, mock_opensearch):
+        # Mock existing document in Elasticsearch
+        mock_es = mock_opensearch.return_value
+        mock_es.search.return_value = {'hits': {'hits': [{'id': '1', '_source': {'url': 'http://example.com'}}]}}
+        mock_es.delete.return_value = {'result': 'deleted'}
+
+        # Test case: Object found and deleted
+        obj = {'url': 'http://example.com'}
+        result = delete(obj)
+
+        self.assertTrue(result['result'] == 'deleted')
+
+        # Test case: Object not found
+        mock_es.search.return_value = {'hits': {'hits': []}}
+        result = delete(obj)
+
+        self.assertFalse(result['result'])
+
+    @patch('app.main.lib.elastic_crud.OpenSearch')
+    @patch('app.main.lib.elastic_crud.save')
+    def test_add(self, mock_save, mock_opensearch):
+        # Setup
+        mock_es = mock_opensearch.return_value
+        mock_es.search.return_value = {'hits': {'hits': []}}
+        mock_save.return_value = {'result': 'created'}
+
+        obj = {'url': 'http://example.com'}
+        result = add(obj)
+
+        self.assertTrue(result['success'])
+        mock_save.assert_called_once_with(obj)
+
+    @patch('app.main.lib.elastic_crud.OpenSearch')
+    def test_get_by_doc_id_or_url(self, mock_opensearch):
+        # Mock existing document in Elasticsearch
+        mock_es = mock_opensearch.return_value
+        mock_es.search.return_value = {'hits': {'hits': [{'id': '1', '_source': {'url': 'http://example.com', 'doc_id': '123'}}]}}
+
+        # Test case where doc_id matches
+        obj = {'doc_id': '123'}
+        result = get_by_doc_id_or_url(obj)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['doc_id'], '123')
+
+        # Test case where url matches
+        obj = {'url': 'http://example.com'}
+        result = get_by_doc_id_or_url(obj)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['url'], 'http://example.com')
+
+        # Test case where neither doc_id nor url matches
+        mock_es.search.return_value = {'hits': {'hits': []}}
+        obj = {'doc_id': 'nonexistent-doc-id', 'url': 'http://nonexistent.com'}
+        result = get_by_doc_id_or_url(obj)
+        self.assertIsNone(result)
+
+    @patch('app.main.lib.elastic_crud.OpenSearch')
+    @patch('app.main.lib.elastic_crud.add')
+    def test_get_object_existing(self, mock_add, mock_opensearch):
+        # Scenario: Object exists in Elasticsearch
+        mock_es = mock_opensearch.return_value
+        mock_es.search.return_value = {'hits': {'hits': [{'id': '1', '_source': {'url': 'http://example.com', 'doc_id': '123'}}]}}
+
+        obj = {'doc_id': '123'}
+        result, temporary = get_object(obj)
+
+        self.assertIsNotNone(result)
+        self.assertFalse(temporary)
+        mock_add.assert_not_called()
+
+    @patch('app.main.lib.elastic_crud.OpenSearch')
+    @patch('app.main.lib.elastic_crud.add')
+    def test_get_object_temporary(self, mock_add, mock_opensearch):
+        # Scenario: Object does not exist in Elasticsearch and is temporarily added
+        mock_es = mock_opensearch.return_value
+        mock_es.search.side_effect = [{'hits': {'hits': []}}, {'hits': {'hits': [{'id': '1', '_source': {'url': 'http://example.com', 'doc_id': '123'}}]}}]
+        mock_add.return_value = None
+
+        obj = {'url': 'http://example.com'}
+        result, temporary = get_object(obj)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(temporary)
+        mock_add.assert_called_once()
+        self.assertIn('doc_id', obj)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/test/test_elastic_crud.py
+++ b/app/test/test_elastic_crud.py
@@ -78,7 +78,7 @@ class TestElasticCrud(unittest.TestCase):
     def test_get_blocked_presto_response(self, mock_store_document, mock_send_request):
         mock_send_request.return_value = MagicMock(text=json.dumps({
             'message': 'Message pushed successfully',
-            'queue': 'some_queue',
+            'queue': 'mean_tokens__Model',
             'body': {'doc_id': '123'}
         }))
         
@@ -97,13 +97,13 @@ class TestElasticCrud(unittest.TestCase):
     def test_get_async_presto_response(self, mock_store_document, mock_send_request):
         mock_send_request.return_value = MagicMock(text=json.dumps({
             'message': 'Message pushed successfully',
-            'queue': 'some_queue',
+            'queue': 'mean_tokens__Model',
             'body': {'doc_id': '123'}
         }))
 
         task = {'url': 'http://example.com', 'context': {'foo': 'bar'}}
         model = MagicMock()
-        modality = 'test_modality'
+        modality = 'meantokens'
 
         result = get_async_presto_response(task, model, modality)
         self.assertIsNotNone(result)

--- a/app/test/test_elastic_crud.py
+++ b/app/test/test_elastic_crud.py
@@ -1,139 +1,124 @@
+import unittest
 from unittest.mock import patch, MagicMock
 from flask import current_app as app
-from opensearchpy import OpenSearch, TransportError
-from app.main.lib.elastic_crud import save, delete, add, get_by_doc_id_or_url, get_object
-import unittest
+from opensearchpy import OpenSearch
 import json
+import uuid
 
+from app.main.lib.elastic_crud import (
+    get_object_by_doc_id,
+    get_object,
+    get_context_for_search,
+    get_presto_request_response,
+    requires_encoding,
+    get_blocked_presto_response,
+    get_async_presto_response,
+    parse_task_search
+)
 
 class TestElasticCrud(unittest.TestCase):
-    @patch('app.main.lib.elastic_crud.OpenSearch')
-    def test_save_existing_object(self, mock_opensearch):
-        # Mock existing document in Elasticsearch
-        mock_es = mock_opensearch.return_value
-        mock_es.search.return_value = {'hits': {'hits': [{'id': '1', '_source': {'url': 'http://example.com', 'context': [{'foo': 'bar'}, {'baz': 'bat'}]}}]}}
-        mock_es.index.return_value = {'result': 'updated'}
+    @patch('app.main.lib.elastic_crud.get_by_doc_id')
+    def test_get_object_by_doc_id(self, mock_get_by_doc_id):
+        mock_get_by_doc_id.return_value = {'doc_id': '123', 'content': 'test content'}
+        
+        result = get_object_by_doc_id('123')
+        self.assertEqual(result, {'doc_id': '123', 'content': 'test content'})
+        mock_get_by_doc_id.assert_called_once_with('123')
 
-        # Calling save function with an object having the same URL
-        obj = {'url': 'http://example.com', 'context': [{'foo': 'bar'}, {'baz': 'bat'}]}
-        result = save(obj)
-
-        # Check if existing object is updated in Elasticsearch
-        self.assertTrue(result['result'] == 'updated')
-
-    @patch('app.main.lib.elastic_crud.OpenSearch')
-    def test_save_new_object(self, mock_opensearch):
-        # Mock no existing document in Elasticsearch
-        mock_es = mock_opensearch.return_value
-        mock_es.search.return_value = {'hits': {'hits': []}}
-        mock_es.index.return_value = {'result': 'created'}
-
-        # Calling save function with a new object
-        obj = {'url': 'http://newexample.com', 'context': 'new_context'}
-        result = save(obj)
-
-        # Check if new object is added in Elasticsearch
-        self.assertTrue(result['result'] == 'created')
-
-    @patch('app.main.lib.elastic_crud.OpenSearch')
-    def test_save_exception_handling(self, mock_opensearch):
-        # Mocking an exception during the save process
-        mock_es = mock_opensearch.return_value
-        mock_es.index.side_effect = TransportError(500, 'Internal Server Error')
-
-        obj = {'url': 'http://exceptionexample.com', 'context': 'new_context'}
-
-        # Expecting an exception to be raised
-        with self.assertRaises(TransportError):
-            save(obj)
-
-    @patch('app.main.lib.elastic_crud.OpenSearch')
-    def test_delete(self, mock_opensearch):
-        # Mock existing document in Elasticsearch
-        mock_es = mock_opensearch.return_value
-        mock_es.search.return_value = {'hits': {'hits': [{'id': '1', '_source': {'url': 'http://example.com'}}]}}
-        mock_es.delete.return_value = {'result': 'deleted'}
-
-        # Test case: Object found and deleted
-        obj = {'url': 'http://example.com'}
-        result = delete(obj)
-
-        self.assertTrue(result['result'] == 'deleted')
-
-        # Test case: Object not found
-        mock_es.search.return_value = {'hits': {'hits': []}}
-        result = delete(obj)
-
-        self.assertFalse(result['result'])
-
-    @patch('app.main.lib.elastic_crud.OpenSearch')
-    @patch('app.main.lib.elastic_crud.save')
-    def test_add(self, mock_save, mock_opensearch):
-        # Setup
-        mock_es = mock_opensearch.return_value
-        mock_es.search.return_value = {'hits': {'hits': []}}
-        mock_save.return_value = {'result': 'created'}
-
-        obj = {'url': 'http://example.com'}
-        result = add(obj)
-
-        self.assertTrue(result['success'])
-        mock_save.assert_called_once_with(obj)
-
-    @patch('app.main.lib.elastic_crud.OpenSearch')
-    def test_get_by_doc_id_or_url(self, mock_opensearch):
-        # Mock existing document in Elasticsearch
-        mock_es = mock_opensearch.return_value
-        mock_es.search.return_value = {'hits': {'hits': [{'id': '1', '_source': {'url': 'http://example.com', 'doc_id': '123'}}]}}
-
-        # Test case where doc_id matches
-        obj = {'doc_id': '123'}
-        result = get_by_doc_id_or_url(obj)
-        self.assertIsNotNone(result)
-        self.assertEqual(result['doc_id'], '123')
-
-        # Test case where url matches
-        obj = {'url': 'http://example.com'}
-        result = get_by_doc_id_or_url(obj)
-        self.assertIsNotNone(result)
-        self.assertEqual(result['url'], 'http://example.com')
-
-        # Test case where neither doc_id nor url matches
-        mock_es.search.return_value = {'hits': {'hits': []}}
-        obj = {'doc_id': 'nonexistent-doc-id', 'url': 'http://nonexistent.com'}
-        result = get_by_doc_id_or_url(obj)
-        self.assertIsNone(result)
-
-    @patch('app.main.lib.elastic_crud.OpenSearch')
-    @patch('app.main.lib.elastic_crud.add')
-    def test_get_object_existing(self, mock_add, mock_opensearch):
-        # Scenario: Object exists in Elasticsearch
-        mock_es = mock_opensearch.return_value
-        mock_es.search.return_value = {'hits': {'hits': [{'id': '1', '_source': {'url': 'http://example.com', 'doc_id': '123'}}]}}
-
-        obj = {'doc_id': '123'}
-        result, temporary = get_object(obj)
-
-        self.assertIsNotNone(result)
+    @patch('app.main.lib.elastic_crud.store_document')
+    def test_get_object(self, mock_store_document):
+        task = {'doc_id': '123', 'content': 'test content'}
+        model = MagicMock()
+        
+        result, temporary = get_object(task, model)
         self.assertFalse(temporary)
-        mock_add.assert_not_called()
+        self.assertEqual(result['doc_id'], '123')
+        self.assertEqual(result['content'], 'test content')
+        mock_store_document.assert_called_once_with(task, '123', None)
 
-    @patch('app.main.lib.elastic_crud.OpenSearch')
-    @patch('app.main.lib.elastic_crud.add')
-    def test_get_object_temporary(self, mock_add, mock_opensearch):
-        # Scenario: Object does not exist in Elasticsearch and is temporarily added
-        mock_es = mock_opensearch.return_value
-        mock_es.search.side_effect = [{'hits': {'hits': []}}, {'hits': {'hits': [{'id': '1', '_source': {'url': 'http://example.com', 'doc_id': '123'}}]}}]
-        mock_add.return_value = None
+    def test_get_context_for_search(self):
+        task = {'context': {'key1': 'value1', 'content_type': 'type1', 'project_media_id': 'id1'}}
+        expected_context = {'content_type': 'type1', 'key1': 'value1', 'project_media_id': 'id1'}
+        self.assertEqual(get_context_for_search(task), expected_context)
 
-        obj = {'url': 'http://example.com'}
-        result, temporary = get_object(obj)
+        task = {'context': {'key1': 'value1', 'content_type': 'type1', 'project_media_id': 'id1'}, 'match_across_content_types': True}
+        expected_context = {'key1': 'value1', 'project_media_id': 'id1'}
+        self.assertEqual(get_context_for_search(task), expected_context)
 
+        task = {}
+        expected_context = {}
+        self.assertEqual(get_context_for_search(task), expected_context)
+
+    @patch('app.main.lib.elastic_crud.Presto.send_request')
+    def test_get_presto_request_response(self, mock_send_request):
+        mock_send_request.return_value = MagicMock(text=json.dumps({
+            'message': 'Message pushed successfully',
+            'queue': 'some_queue',
+            'body': {'doc_id': '123'}
+        }))
+
+        task = {'doc_id': '123', 'content': 'test content'}
+        modality = 'test_modality'
+        callback_url = 'http://example.com/callback'
+
+        result = get_presto_request_response(modality, callback_url, task)
+        self.assertEqual(result['message'], 'Message pushed successfully')
+        self.assertEqual(result['queue'], 'some_queue')
+        self.assertEqual(result['body']['doc_id'], '123')
+
+    def test_requires_encoding(self):
+        obj = {'models': ['model1', 'model2'], 'model_model1': 'encoded_data'}
+        self.assertTrue(requires_encoding(obj))
+
+        obj = {'models': ['model1'], 'model_model1': 'encoded_data'}
+        self.assertFalse(requires_encoding(obj))
+
+    @patch('app.main.lib.elastic_crud.Presto.send_request')
+    @patch('app.main.lib.elastic_crud.store_document')
+    def test_get_blocked_presto_response(self, mock_store_document, mock_send_request):
+        mock_send_request.return_value = MagicMock(text=json.dumps({
+            'message': 'Message pushed successfully',
+            'queue': 'some_queue',
+            'body': {'doc_id': '123'}
+        }))
+        
+        task = {'url': 'http://example.com', 'context': {'foo': 'bar'}}
+        model = MagicMock()
+        modality = 'test_modality'
+        
+        result = get_blocked_presto_response(task, model, modality)
         self.assertIsNotNone(result)
-        self.assertTrue(temporary)
-        mock_add.assert_called_once()
-        self.assertIn('doc_id', obj)
+        self.assertEqual(result[0]['doc_id'], task['doc_id'])
+        mock_store_document.assert_called()
+        mock_send_request.assert_called()
 
+    @patch('app.main.lib.elastic_crud.Presto.send_request')
+    @patch('app.main.lib.elastic_crud.store_document')
+    def test_get_async_presto_response(self, mock_store_document, mock_send_request):
+        mock_send_request.return_value = MagicMock(text=json.dumps({
+            'message': 'Message pushed successfully',
+            'queue': 'some_queue',
+            'body': {'doc_id': '123'}
+        }))
+
+        task = {'url': 'http://example.com', 'context': {'foo': 'bar'}}
+        model = MagicMock()
+        modality = 'test_modality'
+
+        result = get_async_presto_response(task, model, modality)
+        self.assertIsNotNone(result)
+
+    def test_parse_task_search(self):
+        task = {'body': {'raw': {'threshold': 0.5, 'limit': 10}, 'result': {'hash_value': 'hash123'}, 'context': {'key1': 'value1'}}}
+        body, threshold, limit = parse_task_search(task)
+        self.assertEqual(body['hash_value'], 'hash123')
+        self.assertEqual(threshold, 0.5)
+        self.assertEqual(limit, 10)
+
+        task = {'raw': {'threshold': 0.3}, 'limit': 5, 'context': {'key1': 'value1'}}
+        body, threshold, limit = parse_task_search(task)
+        self.assertEqual(threshold, 0.3)
+        self.assertEqual(limit, 5)
 
 if __name__ == '__main__':
     unittest.main()

--- a/app/test/test_media_crud.py
+++ b/app/test/test_media_crud.py
@@ -1,7 +1,8 @@
 from unittest.mock import ANY
 import unittest
 from unittest.mock import patch, MagicMock
-from app.main.lib.media_crud import merge_dict_lists, tmk_file_path, save, delete, add, get_by_doc_id_or_url, get_object, get_context_for_search, get_blocked_presto_response, get_async_presto_response
+from app.main.lib.helpers import merge_dict_lists
+from app.main.lib.media_crud import tmk_file_path, save, delete, add, get_by_doc_id_or_url, get_object, get_context_for_search, get_blocked_presto_response, get_async_presto_response
 from app.main import db
 from flask import current_app as app
 from app.main.lib.presto import Presto, PRESTO_MODEL_MAP

--- a/app/test/test_similarity.py
+++ b/app/test/test_similarity.py
@@ -590,14 +590,14 @@ class TestSimilarityBlueprint(BaseTestCase):
 
             es = OpenSearch(app.config['ELASTICSEARCH_URL'])
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
-            
+
             response = self.client.post(
                 '/text/similarity/search/',
                 data=json.dumps(data),
                 content_type='application/json'
             )
             result = json.loads(response.data.decode())
-            
+
             self.assertEqual(1, len(result['result']))
             data['min_es_score']=10+result['result'][0]['_score']
 


### PR DESCRIPTION
## Description
In this ticket, I'm adding functionality for Alegre to serve text encoding responses both in the original, soon-to-be-deprecated way, as well as via presto. Idea is we'll serve both for a bit and slowly work out each individual case to use the new system over time.

Reference: CV2-5011

## How has this been tested?
Tested extensively locally, but I have not tested original pathways, so will be watching carefully with unit tests. Will also need to add more unit tests to accommodate all these changes.

## Have you considered secure coding practices when writing this code?
None particularly relevant here.
