### PR TITLE
CV2-5082 add logic to suppress a callback event to check-api when explicitly requested

### DIFF
--- a/app/main/controller/presto_controller.py
+++ b/app/main/controller/presto_controller.py
@@ -30,17 +30,20 @@ class PrestoResource(Resource):
         if action == "add_item":
             app.logger.info(f"Data looks like {data}")
             result = similarity.callback_add_item(data.get("body"), model_type)
-            if data.get("body", {}).get("raw", {}).get("final_task") == "search":
-                result = similarity.callback_search_item(data.get("body"), model_type)
-                if result:
-                    result["is_search_result_callback"] = True
-            callback_url = data.get("body", {}).get("raw", {}).get("callback_url", app.config['CHECK_API_HOST']) or app.config['CHECK_API_HOST']
-            if result and data.get("body", {}).get("raw", {}).get("requires_callback"):
-                app.logger.info(f"Sending callback to {callback_url} for {action} for model of {model_type} with body of {result}")
-                Webhook.return_webhook(callback_url, action, model_type, result)
-            output = {"action": action, "model_type": model_type, "data": result}
-            app.logger.info(f"PrestoResource value is {output}")
-            return_value = {"action": action, "model_type": model_type, "data": result}
+            if data.get("body", {}).get("raw", {}).get("suppress_response"):
+                return_value = {"action": action, "model_type": model_type, "data": result}
+            else:
+                if data.get("body", {}).get("raw", {}).get("final_task") == "search":
+                    result = similarity.callback_search_item(data.get("body"), model_type)
+                    if result:
+                        result["is_search_result_callback"] = True
+                callback_url = data.get("body", {}).get("raw", {}).get("callback_url", app.config['CHECK_API_HOST']) or app.config['CHECK_API_HOST']
+                if result and data.get("body", {}).get("raw", {}).get("requires_callback"):
+                    app.logger.info(f"Sending callback to {callback_url} for {action} for model of {model_type} with body of {result}")
+                    Webhook.return_webhook(callback_url, action, model_type, result)
+                output = {"action": action, "model_type": model_type, "data": result}
+                app.logger.info(f"PrestoResource value is {output}")
+                return_value = {"action": action, "model_type": model_type, "data": result}
         r = redis_client.get_client()
         r.lpush(f"{model_type}_{item_id}", json.dumps(data))
         r.expire(f"{model_type}_{item_id}", 60*60*24)

--- a/app/main/controller/presto_controller.py
+++ b/app/main/controller/presto_controller.py
@@ -43,9 +43,8 @@ class PrestoResource(Resource):
                 if result and data.get("body", {}).get("raw", {}).get("requires_callback"):
                     app.logger.info(f"Sending callback to {callback_url} for {action} for model of {model_type} with body of {result}")
                     Webhook.return_webhook(callback_url, action, model_type, result)
-                output = {"action": action, "model_type": model_type, "data": result}
-                app.logger.info(f"PrestoResource value is {output}")
                 return_value = {"action": action, "model_type": model_type, "data": result}
+                app.logger.info(f"PrestoResource value is {return_value}")
         r = redis_client.get_client()
         r.lpush(f"{model_type}_{item_id}", json.dumps(data))
         r.expire(f"{model_type}_{item_id}", 60*60*24)

--- a/app/main/controller/presto_controller.py
+++ b/app/main/controller/presto_controller.py
@@ -35,6 +35,7 @@ class PrestoResource(Resource):
                 return_value = {"action": action, "model_type": model_type, "data": result}
             else:
                 if data.get("body", {}).get("raw", {}).get("final_task") == "search":
+                # compute a set of items that are similar to the just-stored item and respond to caller with them
                     result = similarity.callback_search_item(data.get("body"), model_type)
                     if result:
                         result["is_search_result_callback"] = True

--- a/app/main/controller/presto_controller.py
+++ b/app/main/controller/presto_controller.py
@@ -31,6 +31,7 @@ class PrestoResource(Resource):
             app.logger.info(f"Data looks like {data}")
             result = similarity.callback_add_item(data.get("body"), model_type)
             if data.get("body", {}).get("raw", {}).get("suppress_response"):
+                # requested not to reply to caller with similarity response, so suppress it
                 return_value = {"action": action, "model_type": model_type, "data": result}
             else:
                 if data.get("body", {}).get("raw", {}).get("final_task") == "search":

--- a/app/main/controller/similarity_async_controller.py
+++ b/app/main/controller/similarity_async_controller.py
@@ -33,6 +33,7 @@ class AsyncSimilarityResource(Resource):
         else:
             package = similarity.get_body_for_media_document(args, 'query')
         #Default to true for this endpoint instead of false in most other cases
+        package["suppress_response"] = args.get("suppress_response", False)
         package["requires_callback"] = args.get("requires_callback", True)
         response, waiting_for_callback = similarity.async_get_similar_items(package, similarity_type)
         if not waiting_for_callback:


### PR DESCRIPTION
## Description
In some cases we want to index items to alegre, but we don't care about completing a round trip request back to check-api. This adds an additional parameter that, in conjunction with https://github.com/meedan/check-api/pull/1996 will allow for the ability to suppress a response to Check API.

Reference: CV2-5082

## How has this been tested?
Not yet tested - will likely require its own unit test, for now lets see if it breaks anything

## Have you considered secure coding practices when writing this code?
Nothing in particular of concern here!
