### PR TITLE
CV2-4187-Determine-what-percentage-of-an-image-is-text

### DIFF
--- a/app/main/controller/image_ocr_controller.py
+++ b/app/main/controller/image_ocr_controller.py
@@ -31,6 +31,9 @@ class ImageOcrResource(Resource):
         if response.error.message:
             raise Exception(response.error.message)
 
+        app.logger.info(
+            f"[Alegre OCR] [image_uri {image.source.image_uri}] Image OCR response package looks like {response}")
+
         texts = response.text_annotations
 
         if not texts:

--- a/app/main/controller/image_ocr_controller.py
+++ b/app/main/controller/image_ocr_controller.py
@@ -31,13 +31,13 @@ class ImageOcrResource(Resource):
         if response.error.message:
             raise Exception(response.error.message)
 
-        app.logger.info(
-            f"[Alegre OCR] [image_uri {image.source.image_uri}] Image OCR response package looks like {response}")
-
         texts = response.text_annotations
 
         if not texts:
             return
+
+        app.logger.info(
+            f"[Alegre OCR] [image_uri {image.source.image_uri}] Image OCR response package looks like {response}")
 
         return {
             'text': texts[0].description


### PR DESCRIPTION
## Description
Adding logging to Image OCR response so we can gather data about the boxes size of texts inside images. This later will help determining when do we need to deal with images only as text depending on which percentage of an image is text.

Reference: CV2-4187 (to provide additional context)


