### PR TITLE
CV2-4187-Determine-what-percentage-of-an-image-is-text

### DIFF
--- a/app/main/controller/image_ocr_controller.py
+++ b/app/main/controller/image_ocr_controller.py
@@ -4,6 +4,8 @@ from flask_restplus import Resource, Namespace, fields
 from google.cloud import vision
 import tenacity
 import json
+from google.protobuf.json_format import MessageToJson
+
 
 from app.main.lib.google_client import get_credentialed_google_client
 
@@ -37,8 +39,9 @@ class ImageOcrResource(Resource):
         if not texts:
             return
 
+        res_dict = MessageToDict(response, preserving_proto_field_name=True)
         app.logger.info(
-            f"[Alegre OCR] [image_uri {image.source.image_uri}] Image OCR response package looks like {json.dumps(texts)}")
+            f"[Alegre OCR] [image_uri {image.source.image_uri}] Image OCR response package looks like {json.dumps(res_dict)}")
 
         return {
             'text': texts[0].description

--- a/app/main/controller/image_ocr_controller.py
+++ b/app/main/controller/image_ocr_controller.py
@@ -3,6 +3,7 @@ from urllib3 import Retry
 from flask_restplus import Resource, Namespace, fields
 from google.cloud import vision
 import tenacity
+import json
 
 from app.main.lib.google_client import get_credentialed_google_client
 
@@ -37,7 +38,7 @@ class ImageOcrResource(Resource):
             return
 
         app.logger.info(
-            f"[Alegre OCR] [image_uri {image.source.image_uri}] Image OCR response package looks like {str(response)}")
+            f"[Alegre OCR] [image_uri {image.source.image_uri}] Image OCR response package looks like {json.dumps(texts)}")
 
         return {
             'text': texts[0].description


### PR DESCRIPTION
Adding logging to Image OCR response so we can gather data about the boxes size of texts inside images. This later will help determining when do we need to deal with images only as text depending on which percentage of an image is text.

Reference: CV2-4187 (to provide additional context)