### PR TITLE
CV2-4187-Determine-what-percentage-of-an-image-is-text

### DIFF
--- a/app/main/controller/image_ocr_controller.py
+++ b/app/main/controller/image_ocr_controller.py
@@ -3,9 +3,6 @@ from urllib3 import Retry
 from flask_restplus import Resource, Namespace, fields
 from google.cloud import vision
 import tenacity
-import json
-from google.protobuf.json_format import MessageToJson
-
 
 from app.main.lib.google_client import get_credentialed_google_client
 
@@ -38,10 +35,6 @@ class ImageOcrResource(Resource):
 
         if not texts:
             return
-
-        res_dict = MessageToDict(response, preserving_proto_field_name=True)
-        app.logger.info(
-            f"[Alegre OCR] [image_uri {image.source.image_uri}] Image OCR response package looks like {json.dumps(res_dict)}")
 
         return {
             'text': texts[0].description

--- a/app/main/controller/image_ocr_controller.py
+++ b/app/main/controller/image_ocr_controller.py
@@ -30,10 +30,10 @@ class ImageOcrResource(Resource):
             text_json['bounding_poly'] += [vertice_json]
         text_json = json.dumps(text_json)
         return text_json
+    
     @api.response(200, 'text successfully extracted.')
     @api.doc('Perform text extraction from an image')
     @api.doc(params={'url': 'url of image to extract text from'})
-
     @tenacity.retry(wait=tenacity.wait_exponential(multiplier=1, min=2, max=5), stop=(tenacity.stop_after_attempt(3) | tenacity.stop_after_delay(10)), after=_after_log, reraise=True)
     def post(self):
         image = vision.types.Image()

--- a/app/main/controller/image_ocr_controller.py
+++ b/app/main/controller/image_ocr_controller.py
@@ -30,7 +30,7 @@ class ImageOcrResource(Resource):
             text_json['bounding_poly'] += [vertice_json]
         text_json = json.dumps(text_json)
         return text_json
-    
+
     @api.response(200, 'text successfully extracted.')
     @api.doc('Perform text extraction from an image')
     @api.doc(params={'url': 'url of image to extract text from'})

--- a/app/main/controller/image_ocr_controller.py
+++ b/app/main/controller/image_ocr_controller.py
@@ -1,9 +1,9 @@
+import json
 from flask import request, current_app as app
 from urllib3 import Retry
 from flask_restplus import Resource, Namespace, fields
 from google.cloud import vision
 import tenacity
-import json
 
 from app.main.lib.google_client import get_credentialed_google_client
 from app.main.lib.google_client import convert_text_annotation_to_json

--- a/app/main/controller/image_ocr_controller.py
+++ b/app/main/controller/image_ocr_controller.py
@@ -5,8 +5,7 @@ from flask_restplus import Resource, Namespace, fields
 from google.cloud import vision
 import tenacity
 
-from app.main.lib.google_client import get_credentialed_google_client
-from app.main.lib.google_client import convert_text_annotation_to_json
+from app.main.lib.google_client import get_credentialed_google_client, convert_text_annotation_to_json
 
 api = Namespace('ocr', description='ocr operations')
 ocr_request = api.model('ocr_request', {

--- a/app/main/lib/google_client.py
+++ b/app/main/lib/google_client.py
@@ -40,5 +40,5 @@ def convert_text_annotation_to_json(text_annotation):
             text_json['bounding_poly'] += [vertice_json]
         text_json = json.dumps(text_json)
         return text_json
-    except Exception as e:
-        app.logger.exception(e)
+    except:
+        pass

--- a/app/main/lib/google_client.py
+++ b/app/main/lib/google_client.py
@@ -1,6 +1,7 @@
 import os
 import json
 from google.oauth2 import service_account
+from flask import current_app as app
 
 def get_credentialed_google_client(client):
     default_values = {}
@@ -26,3 +27,18 @@ def get_credentialed_google_client(client):
     except ValueError as e:
       print(f"Couldn't authenticate to google client: {str(e)}")
       return None
+def convert_text_annotation_to_json(text_annotation):
+    try:
+        text_json = {}
+        text_json['description'] = text_annotation.description
+        text_json['locale'] = text_annotation.locale
+        text_json['bounding_poly'] = []
+        for a_vertice in text_annotation.bounding_poly.vertices:
+            vertice_json = {}
+            vertice_json['x'] = a_vertice.x
+            vertice_json['y'] = a_vertice.y
+            text_json['bounding_poly'] += [vertice_json]
+        text_json = json.dumps(text_json)
+        return text_json
+    except Exception as e:
+        app.logger.exception(e)

--- a/app/main/lib/google_client.py
+++ b/app/main/lib/google_client.py
@@ -40,5 +40,5 @@ def convert_text_annotation_to_json(text_annotation):
             text_json['bounding_poly'] += [vertice_json]
         text_json = json.dumps(text_json)
         return text_json
-    except BaseException as e:
+    except Exception as e:
         app.logger.exception(e)

--- a/app/main/lib/google_client.py
+++ b/app/main/lib/google_client.py
@@ -40,5 +40,5 @@ def convert_text_annotation_to_json(text_annotation):
             text_json['bounding_poly'] += [vertice_json]
         text_json = json.dumps(text_json)
         return text_json
-    except:
-        pass
+    except BaseException as e:
+        app.logger.exception(e)


### PR DESCRIPTION
Adding logging to Image OCR response so we can gather data about the boxes size of texts inside images. This later will help determining when do we need to deal with images only as text depending on which percentage of an image is text.

Reference: CV2-4187 (to provide additional context)