### PR TITLE
CV2-5362 Set expiration explicitly on all SharedModel keys

### DIFF
--- a/app/main/lib/shared_models/shared_model.py
+++ b/app/main/lib/shared_models/shared_model.py
@@ -85,6 +85,7 @@ class SharedModel(object):
 
   def send_response(self, task, response):
     self.datastore.set(task.task_id, json.dumps({"response": response}))
+    self.datastore.expire(task.task_id, 60*60*24)
 
   def run(self):
     while True:


### PR DESCRIPTION
## Description
Extremely noncontroversial change - adds an expiry to SharedModel keys.

Reference: CV2-5362

## How has this been tested?
Not tested locally but very standard pattern

## Have you considered secure coding practices when writing this code?
None
