### PR TITLE
Update postgres Docker image to current bookworm slim.

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,16 +1,11 @@
-FROM postgres:13-buster
+FROM postgres:13
 
-MAINTAINER Alexey Kovrizhkin <lekovr+dopos@gmail.com>
+MAINTAINER Martin Peck <martin@meedan.com>
 
 ENV DOCKERFILE_VERSION 190701
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates gnupg2 && \
-    echo 'deb http://deb.debian.org/debian/ buster main contrib non-free' > /etc/apt/sources.list && \
-    echo 'deb http://security.debian.org/debian-security buster/updates main contrib non-free' >> /etc/apt/sources.list && \
-    echo 'deb https://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' >> /etc/apt/sources.list && \
-    apt-key adv --fetch-keys https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
-    apt-get update && \
     apt-get install -y \
     apt-transport-https \
     libcurl3-gnutls \


### PR DESCRIPTION
## Description

This change updates our PostgreSQL docker image used by Alegre. The old buster images were formally End-of-Life's last month.

Reference: [CV2-5363](https://meedan.atlassian.net/browse/CV2-5363)

## How has this been tested?
This needs more testing, particularly the docker entrypoint and combined cluster setup via parent Check repo compose.

## Have you considered secure coding practices when writing this code?

There should only be security improvement by moving to a more current image.

[CV2-5363]: https://meedan.atlassian.net/browse/CV2-5363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ