### PR TITLE
Pin setuptools version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl python3 py3-pip git
-    - pip install setuptools
+    - pip install setuptools==75.1.0
     - pip install urllib3==2.0.6
     - pip install botocore==1.31.62
     - pip install boto3==1.28.62
@@ -91,6 +91,7 @@ deploy_live:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
+    - pip install setuptools==75.1.0
     - pip install urllib3==2.0.6
     - pip install botocore==1.31.62
     - pip install boto3==1.28.62

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,7 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl python3 py3-pip git
+    - pip install setuptools
     - pip install urllib3==2.0.6
     - pip install botocore==1.31.62
     - pip install boto3==1.28.62

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/alegre/api:latest"
   only:
     - develop
+    - bugfix/setuptools-deps
 
 deploy_qa:
   image: python:3-alpine
@@ -56,6 +57,7 @@ deploy_qa:
     - echo "new Image was deployed $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA"
   only:
     - develop
+    - bugfix/setuptools-deps
 
 build_live:
   image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/alegre/api:latest"
   only:
     - develop
-    - bugfix/setuptools-deps
 
 deploy_qa:
   image: python:3-alpine
@@ -58,7 +57,6 @@ deploy_qa:
     - echo "new Image was deployed $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA"
   only:
     - develop
-    - bugfix/setuptools-deps
 
 build_live:
   image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest


### PR DESCRIPTION
## Description

This fix pins the `setuptools` version used by Python for deployments in QA and Live.

## How has this been tested?
A branch deployment was performed to verify the version fix in QA.

## Have you considered secure coding practices when writing this code?
There are no security concerns with this update.