### PR TITLE
CV2-5387: no langid in healthcheck

### DIFF
--- a/app/main/controller/healthcheck_controller.py
+++ b/app/main/controller/healthcheck_controller.py
@@ -19,7 +19,7 @@ class HealthcheckResource(Resource):
       'ELASTICSEARCH_SIMILARITY': False,
       'REDIS': False,
       'DATABASE': False,
-      'LANGID': False
+      # 'LANGID': False
     }
 
     # Elasticsearch
@@ -50,11 +50,11 @@ class HealthcheckResource(Resource):
     except Exception as e:
       result['DATABASE'] = str(e)
 
-    # Langid
-    try:
-      class_ = getattr(importlib.import_module('app.main.lib.langid'), app.config['PROVIDER_LANGID'].title() + 'LangidProvider')
-      result['LANGID'] = class_.test()
-    except Exception as e:
-      result['LANGID'] = '%s: %s' % (app.config['PROVIDER_LANGID'].title() + 'LangidProvider', str(e))
+    # # Langid
+    # try:
+    #   class_ = getattr(importlib.import_module('app.main.lib.langid'), app.config['PROVIDER_LANGID'].title() + 'LangidProvider')
+    #   result['LANGID'] = class_.test()
+    # except Exception as e:
+    #   result['LANGID'] = '%s: %s' % (app.config['PROVIDER_LANGID'].title() + 'LangidProvider', str(e))
 
     return { 'result': result }, 200 if all(x and type(x) == type(True) for x in result.values()) else 500

--- a/app/test/test_healthcheck.py
+++ b/app/test/test_healthcheck.py
@@ -66,11 +66,11 @@ class TestHealthcheckBlueprintWithBadConfig(BaseTestCase):
       self.assertEqual('application/json', response.content_type)
       self.assertEqual(500, response.status_code)
 
-  def test_healthcheck_api_with_import_error(self):
-    with patch.dict('sys.modules', {'app.main.lib.langid': None}):
-      response = self.client.get('/healthcheck/')
-      self.assertEqual('application/json', response.content_type)
-      self.assertEqual(500, response.status_code)
+  # def test_healthcheck_api_with_import_error(self):
+  #   with patch.dict('sys.modules', {'app.main.lib.langid': None}):
+  #     response = self.client.get('/healthcheck/')
+  #     self.assertEqual('application/json', response.content_type)
+  #     self.assertEqual(500, response.status_code)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
We call an external service for language id. We don't want to call that service every few seconds in our health check.

Reference: CV2-5387

## How has this been tested?
Has it been tested locally? Are there automated tests?

## Have you considered secure coding practices when writing this code?
Please list any security concerns that may be relevant.
