### PR TITLE
CV2-5412: Different way to replace new lines for fastext

### DIFF
--- a/app/main/lib/langid.py
+++ b/app/main/lib/langid.py
@@ -1,7 +1,6 @@
 # 3rd party langid providers
 from flask import current_app as app
 import json
-import re
 
 from google.cloud import translate_v2 as translate
 # import requests # Used for MicrosoftLangidProvider
@@ -88,7 +87,7 @@ class FastTextLangidProvider:
   fasttext_model = fasttext.load_model("extra/fasttext_language_id/lid.176.ftz")
   @staticmethod
   def langid(text):
-    prediction = list(FastTextLangidProvider.fasttext_model.predict(re.sub("[\n\r]"," ",text,re.MULTILINE)))
+    prediction = list(FastTextLangidProvider.fasttext_model.predict(text.replace("\n"," ")))
     # prediction is a list of tuples, e.g., [('__label__en',), array([0.22517213])]
 
     language = prediction[0][0].split("__")[-1]


### PR DESCRIPTION
## Description
No idea why, but the `re.sub` approach isn't replacing all newlines. I've tested with failing examples and `.replace` is working on these. Given the issue is only related to `\n` and not to `\r` (https://github.com/facebookresearch/fastText/blob/1142dc4c4ecbc19cc16eee5cdd28472e689267e6/python/fasttext_module/fasttext/FastText.py#L219), I've updated the replace method.

Lesson: Simply is better :upside_down_face: 

Reference: CV2-5412

## How has this been tested?
Has it been tested locally? Are there automated tests?

## Have you considered secure coding practices when writing this code?
Please list any security concerns that may be relevant.
