### PR TITLE
CV2-5050 re-embed item on add event

### DIFF
--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -133,7 +133,7 @@ def callback_add_item(item, similarity_type):
     if function:
         response = function(item)
         app.logger.info(f"[Alegre Similarity] CallbackAddItem: [Item {item}, Similarity type: {similarity_type}] Response looks like {response}")
-        return response
+        return {"item": response}
     else:
         app.logger.warning(f"[Alegre Similarity] InvalidCallbackAddItem: [Item {item}, Similarity type: {similarity_type}] No response")
 

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -131,9 +131,9 @@ def callback_add_item(item, similarity_type):
     elif similarity_type == "text":
         function = callback_add_text
     if function:
-        response = function(item)
+        response = {"item": function(item)}
         app.logger.info(f"[Alegre Similarity] CallbackAddItem: [Item {item}, Similarity type: {similarity_type}] Response looks like {response}")
-        return {"item": response}
+        return response
     else:
         app.logger.warning(f"[Alegre Similarity] InvalidCallbackAddItem: [Item {item}, Similarity type: {similarity_type}] No response")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - "redis:/data"
   postgres:
     build: ./postgres
-    platform: linux/x86_64
+    # platform: linux/x86_64
     ports:
       - "5432:5432"
     volumes:
@@ -124,7 +124,7 @@ services:
   #     MODEL_NAME: audio
   queue_worker:
     build: .
-    platform: linux/x86_64
+    # platform: linux/x86_64
     command: ["make", "run_rq_worker"]
     volumes:
       - ".:/app"
@@ -134,7 +134,7 @@ services:
       - .env_file
   alegre:
     build: .
-    platform: linux/x86_64
+    # platform: linux/x86_64
     ports:
       - "3100:3100"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2'
 volumes:
   elasticsearch:
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 volumes:
   elasticsearch:
   redis:
@@ -30,7 +30,7 @@ services:
       - "redis:/data"
   postgres:
     build: ./postgres
-    # platform: linux/x86_64
+    platform: linux/x86_64
     ports:
       - "5432:5432"
     volumes:
@@ -124,7 +124,7 @@ services:
   #     MODEL_NAME: audio
   queue_worker:
     build: .
-    # platform: linux/x86_64
+    platform: linux/x86_64
     command: ["make", "run_rq_worker"]
     volumes:
       - ".:/app"
@@ -134,7 +134,7 @@ services:
       - .env_file
   alegre:
     build: .
-    # platform: linux/x86_64
+    platform: linux/x86_64
     ports:
       - "3100:3100"
     volumes:


### PR DESCRIPTION
## Description
add_item needs to be embedded with an "item" key in order to play nicely with check-api
Reference: CV2-5050

## How has this been tested?
Relevant local tests appear to pass here, extremely minor tweaks if any are needed.

## Have you considered secure coding practices when writing this code?
None
