### PR TITLE
Pinning Docker Compose version for Travis in order to avoid intermittent Docker errors 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 before_script:
 - ./cc-test-reporter before-build
 - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-- docker compose build --pull
+- docker compose build
 - docker compose -f docker-compose.yml -f docker-test.yml up -d
 - docker compose logs -t -f &
 - echo "Waiting for Elasticsearch indexes..." && until curl --silent --fail -I "http://localhost:9200/alegre_similarity_test"; do sleep 1; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
 - chmod +x ./cc-test-reporter
 before_script:
-- mkdir -p ~/.docker/cli-plugins/ && curl -SL https://github.com/docker/compose/releases/download/v2.3.3/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose && chmod +x ~/.docker/cli-plugins/docker-compose && docker compose version
+- mkdir -p ~/.docker/cli-plugins/ && curl -SL https://github.com/docker/compose/releases/download/v2.30.1/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose && chmod +x ~/.docker/cli-plugins/docker-compose && docker compose version
 - ./cc-test-reporter before-build
 - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 - docker compose build

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,24 @@ before_install:
 before_script:
 - ./cc-test-reporter before-build
 - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-- docker-compose build --pull
-- docker-compose -f docker-compose.yml -f docker-test.yml up -d
-- docker-compose logs -t -f &
+- docker compose build --pull
+- docker compose -f docker compose.yml -f docker-test.yml up -d
+- docker compose logs -t -f &
 - echo "Waiting for Elasticsearch indexes..." && until curl --silent --fail -I "http://localhost:9200/alegre_similarity_test"; do sleep 1; done
 - until curl --silent --fail -I "http://localhost:3100"; do sleep 1; done
 - echo "Waiting for model servers..." && while [[ ! '2' =~ $(redis-cli -n 1 SCARD 'SharedModel') ]]; do sleep 1; done
 #comment until fix timeout curl: (28) Operation timed out
-# - docker-compose exec alegre bash -c "curl --max-time 600.0 -OL https://raw.githubusercontent.com/meedan/check-api/develop/spec/pacts/check_api-alegre.json"
+# - docker compose exec alegre bash -c "curl --max-time 600.0 -OL https://raw.githubusercontent.com/meedan/check-api/develop/spec/pacts/check_api-alegre.json"
 jobs:
   include:
     - stage: tests
       name: unit-tests
-      script: docker-compose exec alegre make test
+      script: docker compose exec alegre make test
     - stage: tests
       name: contract-testing
-      script: docker-compose exec alegre make contract_testing
+      script: docker compose exec alegre make contract_testing
 after_script:
-- docker-compose exec alegre coverage xml
+- docker compose exec alegre coverage xml
 - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_JOB_NAME" != "contract-testing" ]]; then ./cc-test-reporter after-build -t coverage.py -r $CC_TEST_REPORTER_ID --exit-code $TRAVIS_TEST_RESULT; fi
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,24 @@ before_install:
 before_script:
 - ./cc-test-reporter before-build
 - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-- docker-compose build --pull
-- docker-compose -f docker-compose.yml -f docker-test.yml up -d
-- docker-compose logs -t -f &
+- docker compose build --pull
+- docker compose -f docker-compose.yml -f docker-test.yml up -d
+- docker compose logs -t -f &
 - echo "Waiting for Elasticsearch indexes..." && until curl --silent --fail -I "http://localhost:9200/alegre_similarity_test"; do sleep 1; done
 - until curl --silent --fail -I "http://localhost:3100"; do sleep 1; done
 - echo "Waiting for model servers..." && while [[ ! '2' =~ $(redis-cli -n 1 SCARD 'SharedModel') ]]; do sleep 1; done
 #comment until fix timeout curl: (28) Operation timed out
-# - docker-compose exec alegre bash -c "curl --max-time 600.0 -OL https://raw.githubusercontent.com/meedan/check-api/develop/spec/pacts/check_api-alegre.json"
+# - docker compose exec alegre bash -c "curl --max-time 600.0 -OL https://raw.githubusercontent.com/meedan/check-api/develop/spec/pacts/check_api-alegre.json"
 jobs:
   include:
     - stage: tests
       name: unit-tests
-      script: docker-compose exec alegre make test
+      script: docker compose exec alegre make test
     - stage: tests
       name: contract-testing
-      script: docker-compose exec alegre make contract_testing
+      script: docker compose exec alegre make contract_testing
 after_script:
-- docker-compose exec alegre coverage xml
+- docker compose exec alegre coverage xml
 - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_JOB_NAME" != "contract-testing" ]]; then ./cc-test-reporter after-build -t coverage.py -r $CC_TEST_REPORTER_ID --exit-code $TRAVIS_TEST_RESULT; fi
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,24 @@ before_install:
 before_script:
 - ./cc-test-reporter before-build
 - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-- docker compose build --pull
-- docker compose -f docker compose.yml -f docker-test.yml up -d
-- docker compose logs -t -f &
+- docker-compose build --pull
+- docker-compose -f docker-compose.yml -f docker-test.yml up -d
+- docker-compose logs -t -f &
 - echo "Waiting for Elasticsearch indexes..." && until curl --silent --fail -I "http://localhost:9200/alegre_similarity_test"; do sleep 1; done
 - until curl --silent --fail -I "http://localhost:3100"; do sleep 1; done
 - echo "Waiting for model servers..." && while [[ ! '2' =~ $(redis-cli -n 1 SCARD 'SharedModel') ]]; do sleep 1; done
 #comment until fix timeout curl: (28) Operation timed out
-# - docker compose exec alegre bash -c "curl --max-time 600.0 -OL https://raw.githubusercontent.com/meedan/check-api/develop/spec/pacts/check_api-alegre.json"
+# - docker-compose exec alegre bash -c "curl --max-time 600.0 -OL https://raw.githubusercontent.com/meedan/check-api/develop/spec/pacts/check_api-alegre.json"
 jobs:
   include:
     - stage: tests
       name: unit-tests
-      script: docker compose exec alegre make test
+      script: docker-compose exec alegre make test
     - stage: tests
       name: contract-testing
-      script: docker compose exec alegre make contract_testing
+      script: docker-compose exec alegre make contract_testing
 after_script:
-- docker compose exec alegre coverage xml
+- docker-compose exec alegre coverage xml
 - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_JOB_NAME" != "contract-testing" ]]; then ./cc-test-reporter after-build -t coverage.py -r $CC_TEST_REPORTER_ID --exit-code $TRAVIS_TEST_RESULT; fi
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
 - chmod +x ./cc-test-reporter
 before_script:
+- mkdir -p ~/.docker/cli-plugins/ && curl -SL https://github.com/docker/compose/releases/download/v2.3.3/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose && chmod +x ~/.docker/cli-plugins/docker-compose && docker compose version
 - ./cc-test-reporter before-build
 - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 - docker compose build


### PR DESCRIPTION
## Description

We've been facing different errors in Alegre Travis jobs related to Docker, for example:

```
The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services.alegre: 'platform'
Unsupported config option for services.postgres: 'platform'
Unsupported config option for services.queue_worker: 'platform'
```

And:

```
Service 'postgres' failed to build: missing signature key
```

It doesn't happen consistently. Although the Travis file is configured for `dist: jammy` (which is the latest they support), looks like different versions of Docker are used in different jobs.

For now, my suggestion to fix this is by using a pinned version of the latest Docker Compose version. Once we move from Travis to GitHub Actions hopefully this can be more stable and use the latest versions of these packages.

(No ticket created for this).

## How has this been tested?

The Travis job passed after these changes: https://app.travis-ci.com/github/meedan/alegre/builds/272951439
