### PR TITLE
restore _score backwards compatibility (regression in Commit 3063927)

### DIFF
--- a/app/main/lib/text_similarity.py
+++ b/app/main/lib/text_similarity.py
@@ -193,7 +193,8 @@ def return_sources(results):
         May throw an error if source has index and score keys some day, but easy to fix for that,
         and should noisily break since it would have other downstream consequences.
     """
-    return [dict(**r["_source"], **{"_id": r["_id"], "id": r["_id"], "index": r["_index"], "score": r["_score"]}) for r in results]
+    #TODO: remove underscore version after dependencies updated https://meedan.atlassian.net/browse/CV2-5546
+    return [dict(**r["_source"], **{"_id": r["_id"], "id": r["_id"], "index": r["_index"], "_score": r["_score"], "score": r["_score"]}) for r in results]
 
 def strip_vectors(results):
     for result in results:


### PR DESCRIPTION
## Description
Restore _score field accidentally removed in https://github.com/meedan/alegre/commit/3063927b2ac688b6c4f55b971f3a084c1628ed2e#diff-0bfa73717444d8a864c0d082abe33a4b9e42b0e9f5ff0c9660b066cfdb035b8cL196

Expected to resolve https://meedan.sentry.io/issues/6030313816/?environment=qa&project=4506337520451584&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=0

## How has this been tested?
not tested, but was previously working


