### PR TITLE
CV2-5050 fix for null reference error on language resolution

### DIFF
--- a/app/main/lib/langid.py
+++ b/app/main/lib/langid.py
@@ -70,8 +70,8 @@ class Cld3LangidProvider:
     prediction = cld3.get_language(text)
     return {
       'result': {
-        'language': prediction.language,
-        'confidence': prediction.probability
+        'language': prediction and prediction.language,
+        'confidence': prediction and prediction.probability
       },
       'raw': prediction,
       'model': 'CLD3',

--- a/app/test/test_langid.py
+++ b/app/test/test_langid.py
@@ -131,7 +131,7 @@ class TestLangidBlueprint(BaseTestCase):
               'raw': None,
               'model': 'CLD3',
             }
-            self.assertEqual(Cld3LangidProvider.langid("foo bar"), {})
+            self.assertEqual(Cld3LangidProvider.langid("foo bar"), {'model': 'CLD3', 'raw': None, 'result': {'confidence': None, 'language': None}})
 
     def test_langid_api_post(self):
         response = self.client.post(

--- a/app/test/test_langid.py
+++ b/app/test/test_langid.py
@@ -120,6 +120,19 @@ class TestLangidBlueprint(BaseTestCase):
         self.assertEqual('application/json', response.content_type)
         self.assertEqual(200, response.status_code)
 
+    def test_null_prediction_cld(self):
+        with patch('cld3.get_language', ) as mock_cld3_get_language:
+            mock_cld3_get_language.return_value = None
+            expected = {
+              'result': {
+                'language': None,
+                'confidence': None
+              },
+              'raw': None,
+              'model': 'CLD3',
+            }
+            self.assertEqual(Cld3LangidProvider.langid(text), {})
+
     def test_langid_api_post(self):
         response = self.client.post(
             '/text/langid/',

--- a/app/test/test_langid.py
+++ b/app/test/test_langid.py
@@ -131,7 +131,7 @@ class TestLangidBlueprint(BaseTestCase):
               'raw': None,
               'model': 'CLD3',
             }
-            self.assertEqual(Cld3LangidProvider.langid(text), {})
+            self.assertEqual(Cld3LangidProvider.langid("foo bar"), {})
 
     def test_langid_api_post(self):
         response = self.client.post(


### PR DESCRIPTION
## Description
Fixes [this sentry error](https://meedan.sentry.io/issues/6021491026/?project=4504691019677696&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=90d&stream_index=3) where we get a null reference error when missing a language result - better to just propagate nulls than hard fail.

Reference: CV2-5050

## How has this been tested?
Will add unit test for this!

## Have you considered secure coding practices when writing this code?
None