### PR TITLE
CV2-5640 only send responses to check api when we have a fully realized response from presto during sync requests

### DIFF
--- a/app/main/controller/presto_controller.py
+++ b/app/main/controller/presto_controller.py
@@ -39,7 +39,7 @@ class PrestoResource(Resource):
                     if result:
                         result["is_search_result_callback"] = True
                 callback_url = data.get("body", {}).get("raw", {}).get("callback_url", app.config['CHECK_API_HOST']) or app.config['CHECK_API_HOST']
-                if result and data.get("body", {}).get("raw", {}).get("requires_callback"):
+                if result and result.get("results") is not None and data.get("body", {}).get("raw", {}).get("requires_callback"):
                     app.logger.info(f"Sending callback to {callback_url} for {action} for model of {model_type} with body of {result}")
                     Webhook.return_webhook(callback_url, action, model_type, result)
                 return_value = {"action": action, "model_type": model_type, "data": result}

--- a/app/main/lib/elastic_crud.py
+++ b/app/main/lib/elastic_crud.py
@@ -54,7 +54,7 @@ def get_blocked_presto_response(task, model, modality):
     callback_url = Presto.add_item_callback_url(app.config['ALEGRE_HOST'], modality)
     if requires_encoding(obj):
         blocked_results = []
-        for model_key in obj.pop("models", []):
+        for model_key in obj.get("models", []):
             if model_key != "elasticsearch" and not obj.get('model_'+model_key):
                 response = get_presto_request_response(model_key, callback_url, obj)
                 blocked_results.append({"model": model_key, "response": Presto.blocked_response(response, modality)})


### PR DESCRIPTION
## Description
Updates to prevent cases where we send multiple partial matches back to check-api before we've run all vectorizations. The pop that we are removing is theorized as the culprit due to several factors:
1. The pop removes the model, which, on response, makes it appear that there are fewer items waiting to be processed,
2. The pop is only on sync requests, while the nearly identical async requests are using `get` and appear to be working correctly.
3. 
Reference: CV2-5640

## How has this been tested?
Not yet tested locally

## Have you considered secure coding practices when writing this code?
None
