### PR TITLE
Cv2 5861 fix openai embeddings

### DIFF
--- a/app/main/lib/elastic_crud.py
+++ b/app/main/lib/elastic_crud.py
@@ -4,7 +4,7 @@ import json
 from flask import current_app as app
 from app.main.lib.presto import Presto, PRESTO_MODEL_MAP
 from app.main.lib.elasticsearch import store_document, get_by_doc_id
-
+from app.main.lib.openai import PREFIX_OPENAI
 def _after_log(retry_state):
     app.logger.debug("Retrying image similarity...")
 
@@ -42,7 +42,7 @@ def get_presto_request_response(modality, callback_url, task):
 
 def requires_encoding(obj):
     for model_key in obj.get("models", []):
-        if model_key != "elasticsearch" and not obj.get('model_'+model_key):
+        if model_key != "elasticsearch" and not obj.get('model_'+model_key) and model_key[:len(PREFIX_OPENAI)] != PREFIX_OPENAI:
             return True
     return False
 

--- a/app/test/test_elastic_crud.py
+++ b/app/test/test_elastic_crud.py
@@ -73,6 +73,10 @@ class TestElasticCrud(unittest.TestCase):
         obj = {'models': ['model1'], 'model_model1': 'encoded_data'}
         self.assertFalse(requires_encoding(obj))
 
+        obj = {'models': ['openai-text-embedding-ada-002']}
+        self.assertFalse(requires_encoding(obj))
+
+
     @patch('app.main.lib.elastic_crud.Presto.blocked_response')
     @patch('app.main.lib.elastic_crud.Presto.send_request')
     @patch('app.main.lib.elastic_crud.store_document')


### PR DESCRIPTION
## Description
We are currently sending requests to encode OpenAI-based vector embeddings via Presto - instead we need to do those internally on Alegre on the backside of the encoding callback process. All that's needed I believe is to just prevent these from being sent to Presto in the first instance.

Reference: CV2-5681

## How has this been tested?
Not yet tested locally, new tests have been added to cover the regression

## Have you considered secure coding practices when writing this code?
None relevant
