### PR TITLE
[CV2-5845] error when text for similarity is missing

### DIFF
--- a/app/main/controller/similarity_async_controller.py
+++ b/app/main/controller/similarity_async_controller.py
@@ -32,7 +32,7 @@ class AsyncSimilarityResource(Resource):
             package = similarity.get_body_for_text_document(args, 'query')
         else:
             package = similarity.get_body_for_media_document(args, 'query')
-        #Default to true for this endpoint instead of false in most other cases
+        # Default to true for this endpoint instead of false in most other cases
         package["suppress_response"] = args.get("suppress_response", False)
         package["requires_callback"] = args.get("requires_callback", True)
         response, waiting_for_callback = similarity.async_get_similar_items(package, similarity_type)

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -53,6 +53,9 @@ def get_body_for_text_document(params, mode):
       params['content'] = params.get('text')
       del params["text"]
 
+    # Confirm that content is not empty or missing
+    assert (params['content'] is not None and params['content'] != ""), "Similarity cannont be computed for null or missing content text"
+
     # Set defaults
     if 'created_at' not in params:
       params['created_at'] = datetime.now()

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -54,7 +54,7 @@ def get_body_for_text_document(params, mode):
       del params["text"]
 
     # Confirm that content is not empty or missing
-    assert (params['content'] is not None and params['content'] != ""), "Similarity cannot be computed for null or missing content text"
+    assert (params.get('content') is not None and params['content'] != ""), "Similarity cannot be computed for null or missing content text"
 
     # Set defaults
     if 'created_at' not in params:

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -53,8 +53,8 @@ def get_body_for_text_document(params, mode):
       params['content'] = params.get('text')
       del params["text"]
 
-    # Confirm that content is not empty or missing
-    assert (params.get('content') is not None and params['content'] != ""), "Similarity cannot be computed for null or missing content text"
+    # Confirm that content is not empty, missing, or whitespace
+    assert (params.get('content') is not None and params['content'].strip() != ""), "Similarity cannot be computed for null or missing content text"
 
     # Set defaults
     if 'created_at' not in params:

--- a/app/main/lib/similarity.py
+++ b/app/main/lib/similarity.py
@@ -54,7 +54,7 @@ def get_body_for_text_document(params, mode):
       del params["text"]
 
     # Confirm that content is not empty or missing
-    assert (params['content'] is not None and params['content'] != ""), "Similarity cannont be computed for null or missing content text"
+    assert (params['content'] is not None and params['content'] != ""), "Similarity cannot be computed for null or missing content text"
 
     # Set defaults
     if 'created_at' not in params:

--- a/app/test/test_bulk_update_similarity.py
+++ b/app/test/test_bulk_update_similarity.py
@@ -87,7 +87,7 @@ class TestBulkUpdateSimilarityBlueprint(BaseTestCase):
         self.assertEqual(result, expected)
 
     def test_update_existing_doc_values(self):
-        document = {"models": ["model_1"], "context": {"a": 1}}
+        document = {"models": ["model_1"],"text":"dummy text",  "context": {"a": 1}}
         existing_doc = {"contexts": [{"a": 1}]}
         with patch('importlib.import_module', ) as mock_import:
             with patch('app.main.lib.shared_models.shared_model.SharedModel.get_client', ) as mock_get_shared_model_client:
@@ -97,7 +97,7 @@ class TestBulkUpdateSimilarityBlueprint(BaseTestCase):
                     result = bulk_update_similarity_controller.update_existing_doc_values(document, existing_doc)
                     self.assertEqual(result['contexts'], [{'a': 1}])
                     self.assertEqual(result['language'], None)
-                    self.assertEqual(result['content'], None)
+                    self.assertEqual(result['content'], "dummy text")
                     self.assertEqual(result['context'], {'a': 1})
                     self.assertEqual(result['model_model_1'], 1)
                     self.assertEqual(result['vector_model_1'], [0.0])
@@ -118,14 +118,14 @@ class TestBulkUpdateSimilarityBlueprint(BaseTestCase):
         self.assertTrue(result)
 
     def test_get_cases(self):
-        params = {"documents": [{"doc_id": "1", "context": {"a": 1}}, {"doc_id": "2", "context": {"b": 1}}]}
+        params = {"documents": [{"doc_id": "1","text":"dummy text", "context": {"a": 1}}, {"doc_id": "2","text":"dummy text", "context": {"b": 1}}]}
         existing_docs = {"1": {"_source": {"contexts": [{"a": 1}]}}}
         updateable = True
         response = bulk_update_similarity_controller.get_cases(params, existing_docs, updateable)
         self.assertEqual(response[0], ['1'])
         self.assertEqual(response[1][0]['contexts'], [{'a': 1}])
         self.assertEqual(response[1][0]['language'], None)
-        self.assertEqual(response[1][0]['content'], None)
+        self.assertEqual(response[1][0]['content'], "dummy text")
         self.assertEqual(response[1][0]['context'], {'a': 1})
         self.assertEqual(response[1][0]['model_elasticsearch'], 1)
 
@@ -175,14 +175,14 @@ class TestBulkUpdateSimilarityBlueprint(BaseTestCase):
         self.assertEqual(result_values, expected_values)
 
     def test_get_cases_not_updateable(self):
-        params = {"documents": [{"doc_id": "1", "context": {"a": 1}}, {"doc_id": "2", "context": {"a": 1}}]}
+        params = {"documents": [{"doc_id": "1", "text":"dummy text", "context": {"a": 1}}, {"doc_id": "2", "text":"dummy text", "context": {"a": 1}}]}
         existing_docs = {"1": {"_source": {"contexts": [{"a": 1}]}}}
         updateable = False
         response = bulk_update_similarity_controller.get_cases(params, existing_docs, updateable)
         self.assertEqual(response[0], ['2'])
         self.assertEqual(response[1][0]['contexts'], [{'a': 1}])
         self.assertEqual(response[1][0]['language'], None)
-        self.assertEqual(response[1][0]['content'], None)
+        self.assertEqual(response[1][0]['content'], "dummy text")
         self.assertEqual(response[1][0]['context'], {'a': 1})
         self.assertEqual(response[1][0]['model_elasticsearch'], 1)
 

--- a/app/test/test_similarity.py
+++ b/app/test/test_similarity.py
@@ -39,7 +39,7 @@ class TestSimilarityBlueprint(BaseTestCase):
             for term in json.load(open('./app/test/data/similarity.json')):
                 term['text'] = term['content']
                 del term['content']
-                response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+                response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
                 result = json.loads(response.data.decode())
                 self.assertEqual(True, result['success'])
 
@@ -153,7 +153,7 @@ class TestSimilarityBlueprint(BaseTestCase):
                 term['text'] = term['content']
                 term["models"] = ["elasticsearch"]
                 del term['content']
-                response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+                response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
                 result = json.loads(response.data.decode())
                 self.assertEqual(True, result['success'])
 
@@ -284,13 +284,13 @@ class TestSimilarityBlueprint(BaseTestCase):
     def test_elasticsearch_update_text_listed_context(self):
         with self.client:
             term = { 'text': 'how to slice a banana', 'model': 'elasticsearch', 'context': { 'dbid': [54, 55] } }
-            post_response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+            post_response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
             es = OpenSearch(app.config['ELASTICSEARCH_URL'])
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if e["_source"]['content'] == term['text']][0]
             term2 = { 'text': 'how to slice a pizza', 'model': 'elasticsearch', 'context': { 'dbid': [54, 55] }, 'doc_id': doc["_id"]}
-            post_response2 = self.client.post('/text/similarity/', data=json.dumps(term2), content_type='application/json')
+            post_response2 = self.client.post('/similarity/sync/text/', data=json.dumps(term2), content_type='application/json')
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if doc["_id"] == e["_id"]][0]
@@ -299,7 +299,7 @@ class TestSimilarityBlueprint(BaseTestCase):
     def test_elasticsearch_performs_correct_fuzzy_search(self):
         with self.client:
             term = { 'text': 'what even is a banana', 'model': 'elasticsearch', 'context': { 'dbid': 54 } }
-            post_response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+            post_response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
             es = OpenSearch(app.config['ELASTICSEARCH_URL'])
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             lookup = { 'text': 'what even is a bananna', 'model': 'elasticsearch', 'context': { 'dbid': 54 } }
@@ -314,13 +314,13 @@ class TestSimilarityBlueprint(BaseTestCase):
     def test_elasticsearch_update_text(self):
         with self.client:
             term = { 'text': 'how to slice a banana', 'model': 'elasticsearch', 'context': { 'dbid': 54 } }
-            post_response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+            post_response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
             es = OpenSearch(app.config['ELASTICSEARCH_URL'])
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if e["_source"]['content'] == term['text']][0]
             term2 = { 'text': 'how to slice a pizza', 'model': 'elasticsearch', 'context': { 'dbid': 54 }, 'doc_id': doc["_id"]}
-            post_response2 = self.client.post('/text/similarity/', data=json.dumps(term2), content_type='application/json')
+            post_response2 = self.client.post('/similarity/sync/text/', data=json.dumps(term2), content_type='application/json')
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if doc["_id"] == e["_id"]][0]
@@ -329,13 +329,13 @@ class TestSimilarityBlueprint(BaseTestCase):
     def test_elasticsearch_update_text_with_doc_id(self):
         with self.client:
             term = { 'text': 'how to slice a banana', 'model': 'elasticsearch', 'context': { 'dbid': 54 }, 'doc_id': "123456" }
-            post_response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+            post_response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
             es = OpenSearch(app.config['ELASTICSEARCH_URL'])
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if e["_source"]['content'] == term['text']][0]
             term2 = { 'text': 'how to slice a pizza', 'model': 'elasticsearch', 'context': { 'dbid': 54 }, 'doc_id': "123456"}
-            post_response2 = self.client.post('/text/similarity/', data=json.dumps(term2), content_type='application/json')
+            post_response2 = self.client.post('/similarity/sync/text/', data=json.dumps(term2), content_type='application/json')
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if doc["_id"] == e["_id"]][0]
@@ -344,7 +344,7 @@ class TestSimilarityBlueprint(BaseTestCase):
     def test_elasticsearch_delete_404(self):
         with self.client:
             delete_response = self.client.delete(
-                '/text/similarity/',
+                '/similarity/sync/text/',
                 data=json.dumps({"doc_id": "abcdef", "text": "string"}),
                 content_type='application/json'
             )
@@ -353,7 +353,7 @@ class TestSimilarityBlueprint(BaseTestCase):
     def test_elasticsearch_delete_200(self):
         with self.client:
             delete_response = self.client.delete(
-                '/text/similarity/',
+                '/similarity/sync/text/',
                 data=json.dumps({"doc_id": "abcdef", "quiet": True, 'context': { 'dbid': 54 }}),
                 content_type='application/json'
             )
@@ -363,7 +363,7 @@ class TestSimilarityBlueprint(BaseTestCase):
     def test_elasticsearch_delete_text(self):
         with self.client:
             term = { 'text': 'how to slice a banana', 'model': 'elasticsearch', 'context': { 'dbid': 54 } }
-            post_response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+            post_response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
             es = OpenSearch(app.config['ELASTICSEARCH_URL'])
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             result = json.loads(post_response.data.decode())
@@ -372,7 +372,7 @@ class TestSimilarityBlueprint(BaseTestCase):
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if e["_source"]['content'] == term['text']][0]
             delete_response = self.client.delete(
-                '/text/similarity/',
+                '/similarity/sync/text/',
                 data=json.dumps({"doc_id": doc["_id"], 'context': { 'dbid': 54 }}),
                 content_type='application/json'
             )
@@ -380,9 +380,9 @@ class TestSimilarityBlueprint(BaseTestCase):
             self.assertEqual('deleted', result['result'])
         with self.client:
             term = { 'doc_id': '123', 'text': 'how to slice a banana', 'model': 'elasticsearch', 'context': { 'dbid': 54 } }
-            post_response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+            post_response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
             term = { 'doc_id': '123', 'text': 'how to slice a banana', 'model': 'elasticsearch', 'context': { 'dbid': 55 } }
-            post_response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+            post_response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
             es = OpenSearch(app.config['ELASTICSEARCH_URL'])
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             result = json.loads(post_response.data.decode())
@@ -391,7 +391,7 @@ class TestSimilarityBlueprint(BaseTestCase):
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if e["_source"]['content'] == term['text']][0]
             delete_response = self.client.delete(
-                '/text/similarity/',
+                '/similarity/sync/text/',
                 data=json.dumps({"doc_id": doc["_id"], 'context': { 'dbid': 54 }}),
                 content_type='application/json'
             )
@@ -404,7 +404,7 @@ class TestSimilarityBlueprint(BaseTestCase):
               { 'text': 'नमस्ते मेरा नाम करीम है' },
               { 'text': 'हॅलो माझे नाव करीम आहे' }
             ]:
-              response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+              response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
               result = json.loads(response.data.decode())
               self.assertEqual(True, result['success'])
 
@@ -436,7 +436,7 @@ class TestSimilarityBlueprint(BaseTestCase):
     def test_model_similarity(self):
         with self.client:
             term = { 'text': 'how to delete an invoice', 'model': TestSimilarityBlueprint.use_model_key, 'context': { 'dbid': 54 } }
-            response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+            response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
             result = json.loads(response.data.decode())
             self.assertEqual(True, result['success'])
 
@@ -510,7 +510,7 @@ class TestSimilarityBlueprint(BaseTestCase):
         """
         with self.client:
             term = { 'text': 'how to slice a banana', 'model': TestSimilarityBlueprint.use_model_key, 'context': { 'dbid': 54 }}
-            response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+            response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
             result = json.loads(response.data.decode())
             self.assertEqual(True, result['success'])
 
@@ -537,7 +537,7 @@ class TestSimilarityBlueprint(BaseTestCase):
       """
       with self.client:
         term = { 'text': '', 'model': 'elasticsearch', 'context': { 'dbid': 54 }}
-        response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+        response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
         assert response.status_code >= 500
         result = json.loads(response.data.decode())
         self.assertEqual(None, result.get('success'))
@@ -547,7 +547,7 @@ class TestSimilarityBlueprint(BaseTestCase):
     def test_model_similarity_with_vector(self):
       with self.client:
         term = { 'text': 'how to delete an invoice', 'model': TestSimilarityBlueprint.use_model_key, 'context': { 'dbid': 54 }}
-        response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+        response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
         result = json.loads(response.data.decode())
         self.assertEqual(True, result['success'])
 
@@ -576,7 +576,7 @@ class TestSimilarityBlueprint(BaseTestCase):
                 'text':'min_es_score',
                 'models':['elasticsearch'],
             }
-            response = self.client.post('/text/similarity/', data=json.dumps(data), content_type='application/json')
+            response = self.client.post('/similarity/sync/text/', data=json.dumps(data), content_type='application/json')
             result = json.loads(response.data.decode())
             self.assertEqual(True, result['success'])
 

--- a/app/test/test_similarity.py
+++ b/app/test/test_similarity.py
@@ -543,7 +543,7 @@ class TestSimilarityBlueprint(BaseTestCase):
         """
         with self.client:
             term = { 'text': '', 'model': 'elasticsearch', 'context': { 'dbid': 54 }}
-            response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
+            response = self.client.post('/similarity/sync/text', data=json.dumps(term), content_type='application/json')
             assert response.status_code >= 500, f"response status code was {response.status_code}"
             result = json.loads(response.data.decode())
             self.assertEqual(None, result.get('success'))

--- a/app/test/test_similarity.py
+++ b/app/test/test_similarity.py
@@ -544,7 +544,7 @@ class TestSimilarityBlueprint(BaseTestCase):
       with self.client:
         term = { 'text': '', 'model': 'elasticsearch', 'context': { 'dbid': 54 }}
         response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
-        assert response.status_code >= 500
+        assert response.status_code >= 500, f"response status code was {response.status_code}"
         result = json.loads(response.data.decode())
         self.assertEqual(None, result.get('success'))
 

--- a/app/test/test_similarity.py
+++ b/app/test/test_similarity.py
@@ -282,15 +282,16 @@ class TestSimilarityBlueprint(BaseTestCase):
             self.assertEqual(2, len(result['result']))
 
     def test_elasticsearch_update_text_listed_context(self):
+        # TODO: update is still using the /text/similarity/ endpoint https://meedan.atlassian.net/browse/CV2-6016
         with self.client:
             term = { 'text': 'how to slice a banana', 'model': 'elasticsearch', 'context': { 'dbid': [54, 55] } }
-            post_response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
+            post_response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
             es = OpenSearch(app.config['ELASTICSEARCH_URL'])
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if e["_source"]['content'] == term['text']][0]
             term2 = { 'text': 'how to slice a pizza', 'model': 'elasticsearch', 'context': { 'dbid': [54, 55] }, 'doc_id': doc["_id"]}
-            post_response2 = self.client.post('/similarity/sync/text/', data=json.dumps(term2), content_type='application/json')
+            post_response2 = self.client.post('/text/similarity/', data=json.dumps(term2), content_type='application/json')
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if doc["_id"] == e["_id"]][0]
@@ -303,7 +304,7 @@ class TestSimilarityBlueprint(BaseTestCase):
             es = OpenSearch(app.config['ELASTICSEARCH_URL'])
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             lookup = { 'text': 'what even is a bananna', 'model': 'elasticsearch', 'context': { 'dbid': 54 } }
-            post_response = self.client.post('/text/similarity/search/', data=json.dumps(lookup), content_type='application/json')
+            post_response = self.client.post('/similarity/sync/text/', data=json.dumps(lookup), content_type='application/json')
             lookup["fuzzy"] = True
             post_response_fuzzy = self.client.post('/text/similarity/search/', data=json.dumps(lookup), content_type='application/json')
             self.assertGreater(json.loads(post_response_fuzzy.data.decode())["result"][0]["score"], json.loads(post_response.data.decode())["result"][0]["score"])
@@ -312,48 +313,52 @@ class TestSimilarityBlueprint(BaseTestCase):
             self.assertEqual(json.loads(post_response_fuzzy.data.decode())["result"][0]["score"], json.loads(post_response.data.decode())["result"][0]["score"])
 
     def test_elasticsearch_update_text(self):
+        # TODO: update is still using the /text/similarity/ endpoint https://meedan.atlassian.net/browse/CV2-6016
         with self.client:
             term = { 'text': 'how to slice a banana', 'model': 'elasticsearch', 'context': { 'dbid': 54 } }
-            post_response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
+            post_response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
             es = OpenSearch(app.config['ELASTICSEARCH_URL'])
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if e["_source"]['content'] == term['text']][0]
             term2 = { 'text': 'how to slice a pizza', 'model': 'elasticsearch', 'context': { 'dbid': 54 }, 'doc_id': doc["_id"]}
-            post_response2 = self.client.post('/similarity/sync/text/', data=json.dumps(term2), content_type='application/json')
+            post_response2 = self.client.post('/text/similarity/', data=json.dumps(term2), content_type='application/json')
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if doc["_id"] == e["_id"]][0]
             self.assertEqual(term2['text'], doc['_source']['content'])
 
     def test_elasticsearch_update_text_with_doc_id(self):
+        # TODO: update is still using the /text/similarity/ endpoint https://meedan.atlassian.net/browse/CV2-6016
         with self.client:
             term = { 'text': 'how to slice a banana', 'model': 'elasticsearch', 'context': { 'dbid': 54 }, 'doc_id': "123456" }
-            post_response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
+            post_response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
             es = OpenSearch(app.config['ELASTICSEARCH_URL'])
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if e["_source"]['content'] == term['text']][0]
             term2 = { 'text': 'how to slice a pizza', 'model': 'elasticsearch', 'context': { 'dbid': 54 }, 'doc_id': "123456"}
-            post_response2 = self.client.post('/similarity/sync/text/', data=json.dumps(term2), content_type='application/json')
+            post_response2 = self.client.post('/text/similarity/', data=json.dumps(term2), content_type='application/json')
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if doc["_id"] == e["_id"]][0]
             self.assertEqual(term2['text'], doc['_source']['content'])
 
     def test_elasticsearch_delete_404(self):
+        # TODO: delete is still using the /text/similarity/ endpoint https://meedan.atlassian.net/browse/CV2-6016
         with self.client:
             delete_response = self.client.delete(
-                '/similarity/sync/text/',
+                '/text/similarity/',
                 data=json.dumps({"doc_id": "abcdef", "text": "string"}),
                 content_type='application/json'
             )
             self.assertEqual(404, delete_response.status_code)
 
     def test_elasticsearch_delete_200(self):
+        # TODO: delete is still using the /text/similarity/ endpoint https://meedan.atlassian.net/browse/CV2-6016
         with self.client:
             delete_response = self.client.delete(
-                '/similarity/sync/text/',
+                '/text/similarity/',
                 data=json.dumps({"doc_id": "abcdef", "quiet": True, 'context': { 'dbid': 54 }}),
                 content_type='application/json'
             )
@@ -361,9 +366,10 @@ class TestSimilarityBlueprint(BaseTestCase):
             self.assertEqual(200, delete_response.status_code)
 
     def test_elasticsearch_delete_text(self):
+        # TODO: delete is still using the /text/similarity/ endpoint https://meedan.atlassian.net/browse/CV2-6016
         with self.client:
             term = { 'text': 'how to slice a banana', 'model': 'elasticsearch', 'context': { 'dbid': 54 } }
-            post_response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
+            post_response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
             es = OpenSearch(app.config['ELASTICSEARCH_URL'])
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             result = json.loads(post_response.data.decode())
@@ -372,7 +378,7 @@ class TestSimilarityBlueprint(BaseTestCase):
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if e["_source"]['content'] == term['text']][0]
             delete_response = self.client.delete(
-                '/similarity/sync/text/',
+                '/text/similarity/',
                 data=json.dumps({"doc_id": doc["_id"], 'context': { 'dbid': 54 }}),
                 content_type='application/json'
             )
@@ -391,7 +397,7 @@ class TestSimilarityBlueprint(BaseTestCase):
             results = es.search(body={"query": {"match_all": {}}},index=app.config['ELASTICSEARCH_SIMILARITY'])
             doc = [e for e in results["hits"]["hits"] if e["_source"]['content'] == term['text']][0]
             delete_response = self.client.delete(
-                '/similarity/sync/text/',
+                '/text/similarity/',
                 data=json.dumps({"doc_id": doc["_id"], 'context': { 'dbid': 54 }}),
                 content_type='application/json'
             )

--- a/app/test/test_similarity.py
+++ b/app/test/test_similarity.py
@@ -532,15 +532,19 @@ class TestSimilarityBlueprint(BaseTestCase):
         self.assertEqual(0, len(result['result']))
 
     def test_model_similarity_without_text(self):
+      """
+      This should return an error because model cannot compute on empty text
+      """
       with self.client:
-        term = { 'text': 'how to delete an invoice', 'model': 'elasticsearch', 'context': { 'dbid': 54 }}
+        term = { 'text': '', 'model': 'elasticsearch', 'context': { 'dbid': 54 }}
         response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
         result = json.loads(response.data.decode())
         self.assertEqual(True, result['success'])
 
       response = self.client.post(
-            '/text/similarity/search/',
+            '/text/similarity/search/',  # TODO: are these tests running on a deprecated endpoint?
         data=json.dumps({
+          # NOTE: both content and text element ommitted here
           'model': TestSimilarityBlueprint.use_model_key,
           'threshold': 0.7,
           'context': {
@@ -549,8 +553,8 @@ class TestSimilarityBlueprint(BaseTestCase):
         }),
         content_type='application/json'
       )
-      result = json.loads(response.data.decode())
-      self.assertEqual(0, len(result['result']))
+      # expected to return an error
+      assert response.status_code >= 500
 
     def test_model_similarity_with_vector(self):
       with self.client:

--- a/app/test/test_similarity.py
+++ b/app/test/test_similarity.py
@@ -548,7 +548,7 @@ class TestSimilarityBlueprint(BaseTestCase):
             result = json.loads(response.data.decode())
             self.assertEqual(None, result.get('success'))
 
-    def test_model_similarity_without_text(self):
+    def test_model_similarity_without_text_deprecated(self):
         """
         This should return an error because model cannot compute on empty text
         NOTE: this is using the deprecated text endpoint expected to be removed

--- a/app/test/test_similarity.py
+++ b/app/test/test_similarity.py
@@ -304,7 +304,7 @@ class TestSimilarityBlueprint(BaseTestCase):
             es = OpenSearch(app.config['ELASTICSEARCH_URL'])
             es.indices.refresh(index=app.config['ELASTICSEARCH_SIMILARITY'])
             lookup = { 'text': 'what even is a bananna', 'model': 'elasticsearch', 'context': { 'dbid': 54 } }
-            post_response = self.client.post('/text/similarity/', data=json.dumps(lookup), content_type='application/json')
+            post_response = self.client.post('/text/similarity/search/', data=json.dumps(lookup), content_type='application/json')
             lookup["fuzzy"] = True
             post_response_fuzzy = self.client.post('/text/similarity/search/', data=json.dumps(lookup), content_type='application/json')
             self.assertGreater(json.loads(post_response_fuzzy.data.decode())["result"][0]["score"], json.loads(post_response.data.decode())["result"][0]["score"])
@@ -442,7 +442,7 @@ class TestSimilarityBlueprint(BaseTestCase):
     def test_model_similarity(self):
         with self.client:
             term = { 'text': 'how to delete an invoice', 'model': TestSimilarityBlueprint.use_model_key, 'context': { 'dbid': 54 } }
-            response = self.client.post('/similarity/sync/text/', data=json.dumps(term), content_type='application/json')
+            response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
             result = json.loads(response.data.decode())
             self.assertEqual(True, result['success'])
 

--- a/app/test/test_similarity.py
+++ b/app/test/test_similarity.py
@@ -538,23 +538,11 @@ class TestSimilarityBlueprint(BaseTestCase):
       with self.client:
         term = { 'text': '', 'model': 'elasticsearch', 'context': { 'dbid': 54 }}
         response = self.client.post('/text/similarity/', data=json.dumps(term), content_type='application/json')
+        assert response.status_code >= 500
         result = json.loads(response.data.decode())
-        self.assertEqual(True, result['success'])
+        self.assertEqual(None, result.get('success'))
 
-      response = self.client.post(
-            '/text/similarity/search/',  # TODO: are these tests running on a deprecated endpoint?
-        data=json.dumps({
-          # NOTE: both content and text element ommitted here
-          'model': TestSimilarityBlueprint.use_model_key,
-          'threshold': 0.7,
-          'context': {
-            'dbid': 54
-          }
-        }),
-        content_type='application/json'
-      )
-      # expected to return an error
-      assert response.status_code >= 500
+
 
     def test_model_similarity_with_vector(self):
       with self.client:

--- a/app/test/test_similarity_lang_analyzers.py
+++ b/app/test/test_similarity_lang_analyzers.py
@@ -33,7 +33,7 @@ class TestSimilarityBlueprint(BaseTestCase):
         examples = [{ 'text': 'केले को कैसे काटें', 'language': 'hi'}, {'text': 'how to slice a banana', 'language': 'en'}, {'text': 'como rebanar un plátano', 'language': 'es'}, {'text': 'কিভাবে একটি কলা টুকরা করা হয়', 'language': 'bn'}]
         with self.client:
             for example in examples:
-                response = self.client.post('/similarity/sync/text/', data=json.dumps(example), content_type='application/json')
+                response = self.client.post('/text/similarity/', data=json.dumps(example), content_type='application/json')
                 result = json.loads(response.data.decode())
                 self.assertEqual(True, result['success'])
                 es = OpenSearch(app.config['ELASTICSEARCH_URL'])
@@ -64,7 +64,7 @@ class TestSimilarityBlueprint(BaseTestCase):
             for n in range(len(examples)):
                 example = examples[n]
                 expected_lang = expected_lang_ids[n]
-                response = self.client.post('/similarity/sync/text/', data=json.dumps(example), content_type='application/json')
+                response = self.client.post('/text/similarity/', data=json.dumps(example), content_type='application/json')
                 result = json.loads(response.data.decode()) # we are feeding in 'auto' expected correct id back
                 self.assertEqual(True, result['success'])
                 es = OpenSearch(app.config['ELASTICSEARCH_URL'])

--- a/app/test/test_similarity_lang_analyzers.py
+++ b/app/test/test_similarity_lang_analyzers.py
@@ -33,7 +33,7 @@ class TestSimilarityBlueprint(BaseTestCase):
         examples = [{ 'text': 'केले को कैसे काटें', 'language': 'hi'}, {'text': 'how to slice a banana', 'language': 'en'}, {'text': 'como rebanar un plátano', 'language': 'es'}, {'text': 'কিভাবে একটি কলা টুকরা করা হয়', 'language': 'bn'}]
         with self.client:
             for example in examples:
-                response = self.client.post('/text/similarity/', data=json.dumps(example), content_type='application/json')
+                response = self.client.post('/similarity/sync/text/', data=json.dumps(example), content_type='application/json')
                 result = json.loads(response.data.decode())
                 self.assertEqual(True, result['success'])
                 es = OpenSearch(app.config['ELASTICSEARCH_URL'])
@@ -64,7 +64,7 @@ class TestSimilarityBlueprint(BaseTestCase):
             for n in range(len(examples)):
                 example = examples[n]
                 expected_lang = expected_lang_ids[n]
-                response = self.client.post('/text/similarity/', data=json.dumps(example), content_type='application/json')
+                response = self.client.post('/similarity/sync/text/', data=json.dumps(example), content_type='application/json')
                 result = json.loads(response.data.decode()) # we are feeding in 'auto' expected correct id back
                 self.assertEqual(True, result['success'])
                 es = OpenSearch(app.config['ELASTICSEARCH_URL'])
@@ -102,7 +102,7 @@ class TestSimilarityBlueprint(BaseTestCase):
           for n in range(len(examples)):
               example = examples[n]
               expected_lang = expected_lang_ids[n]
-              response = self.client.post('/text/similarity/', data=json.dumps(example), content_type='application/json')
+              response = self.client.post('/similarity/sync/text/', data=json.dumps(example), content_type='application/json')
               result = json.loads(response.data.decode()) # we are feeding in 'auto' expected correct id back
               self.assertEqual(True, result['success'])
               es = OpenSearch(app.config['ELASTICSEARCH_URL'])

--- a/app/test/test_similarity_lang_analyzers.py
+++ b/app/test/test_similarity_lang_analyzers.py
@@ -102,7 +102,7 @@ class TestSimilarityBlueprint(BaseTestCase):
           for n in range(len(examples)):
               example = examples[n]
               expected_lang = expected_lang_ids[n]
-              response = self.client.post('/similarity/sync/text/', data=json.dumps(example), content_type='application/json')
+              response = self.client.post('/text/similarity/', data=json.dumps(example), content_type='application/json')
               result = json.loads(response.data.decode()) # we are feeding in 'auto' expected correct id back
               self.assertEqual(True, result['success'])
               es = OpenSearch(app.config['ELASTICSEARCH_URL'])


### PR DESCRIPTION
## Description

Adding assertion so that attempting to process a similarity request with content or text missing or None will cause error (and assuming exception will result in error code returned by flask)

This caused some of the tests of the bulk similarity endpoint to fail because they didn't include text in the test payload, so I added some dummy text

Also realized that the similarity tests were still executing against the old text similarity endpoint (and I couldn't find any corresponding tests for the new endpoint) so switched them to the new endpoint

Reference: https://meedan.atlassian.net/browse/CV2-5874

## How has this been tested?
not yet

## Have you considered secure coding practices when writing this code?
Please list any security concerns that may be relevant.
