### PR TITLE
CV2-5992 fix bad variable name

### DIFF
--- a/app/main/lib/shared_models/video_model.py
+++ b/app/main/lib/shared_models/video_model.py
@@ -121,9 +121,9 @@ class VideoModel():
         result = self.get_blocked_response(task).get("body")
         s3_folder = (result.get("result", {}) or {}).get("folder")
         s3_filepath = (result.get("result", {}) or {}).get("filepath")
-        tempfile = self.get_tempfile()
-        folder = str.join("/", tempfile.name.split("/")[0:-1])
-        filepath = tempfile.name.split("/")[-1]
+        temp_file = self.get_tempfile()
+        folder = str.join("/", temp_file.name.split("/")[0:-1])
+        filepath = temp_file.name.split("/")[-1]
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
             folder = os.path.dirname(tmp.name)
             filepath = os.path.basename(tmp.name)

--- a/app/test/test_video_similarity.py
+++ b/app/test/test_video_similarity.py
@@ -131,5 +131,23 @@ class TestVideoSimilarityBlueprint(BaseTestCase):
             results = self.model.search_by_context({"blah": 2})
             self.assertEqual(results, [])
 
+    def test_download_temp_file(self):
+        task = {"task_id": "123"}
+        mocked_response = {
+            "body": {
+                "result": {
+                    "folder": "mocked_folder",
+                    "filepath": "mocked_filepath"
+                }
+            }
+        }
+        with patch('app.main.lib.shared_models.video_model.download_file_from_s3', return_value=True) as mock_download, \
+             patch.object(VideoModel, 'get_blocked_response', return_value=mocked_response) as mock_get_response, \
+             patch.object(VideoModel, 'get_tempfile') as mock_tempfile:
+            mock_tempfile.return_value.name = "/mocked/tempfile/path"
+            folder, filepath = self.model.download_temp_file(task)
+            mock_get_response.assert_called_once_with(task)
+            mock_download.assert_called_once()
+
 if __name__ == '__main__':
   unittest.main()

--- a/app/test/test_video_similarity.py
+++ b/app/test/test_video_similarity.py
@@ -141,10 +141,9 @@ class TestVideoSimilarityBlueprint(BaseTestCase):
                 }
             }
         }
+        
         with patch('app.main.lib.shared_models.video_model.download_file_from_s3', return_value=True) as mock_download, \
-             patch.object(VideoModel, 'get_blocked_response', return_value=mocked_response) as mock_get_response, \
-             patch.object(VideoModel, 'get_tempfile') as mock_tempfile:
-            mock_tempfile.return_value.name = "/mocked/tempfile/path"
+             patch.object(VideoModel, 'get_blocked_response', return_value=mocked_response) as mock_get_response:
             folder, filepath = self.model.download_temp_file(task)
             mock_get_response.assert_called_once_with(task)
             mock_download.assert_called_once()


### PR DESCRIPTION
## Description
Minor tweak, no idea how this would have ever worked without the tweak but we need to not step on an imported variable for a variable name.

Reference: CV2-5992

## How has this been tested?
Unit test covers this function run such that a similarly bad named case would yield an error in the future

## Have you considered secure coding practices when writing this code?
None
