### PR TITLE
CV2-5993 add another exception in case of request error

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -272,6 +272,7 @@ def init():
   except (TransportError, RequestError) as e:
     # ignore already existing index
     if e.error in ['resource_already_exists_exception', 'invalid_index_name_exception']:
+      app.logger.debug(f"Bypassing attempt to create index as it already exists! Error was {e.error}.")
       pass
     else:
       raise

--- a/manage.py
+++ b/manage.py
@@ -4,7 +4,7 @@ import json
 
 from flask_migrate import Migrate, MigrateCommand
 from flask_script import Manager
-from opensearchpy import OpenSearch, TransportError
+from opensearchpy import OpenSearch, TransportError, RequestError
 import sqlalchemy
 from sqlalchemy import text
 from sqlalchemy.schema import DDL
@@ -269,9 +269,9 @@ def init():
     if config_name == 'test':
       es.indices.delete(index=app.config['ELASTICSEARCH_SIMILARITY'], ignore=[400, 404])
     es.indices.create(index=app.config['ELASTICSEARCH_SIMILARITY'])
-  except TransportError as e:
+  except (TransportError, RequestError) as e:
     # ignore already existing index
-    if e.error == 'resource_already_exists_exception':
+    if e.error in ['resource_already_exists_exception', 'invalid_index_name_exception']:
       pass
     else:
       raise


### PR DESCRIPTION
## Description
`RequestError(400, 'invalid_index_name_exception', 'Invalid index name [alegre_similarity], already exists as alias')`

From weekly error review, this looks like just another case we should bypass, when we attempt to create an index but it already exists (and as such we should bypass)

Reference: CV2-5993

## How has this been tested?
Not an easy way to test locally, but was able to instantiate a `RequestError` locally and looks like this should catch the conditions correctly!

## Have you considered secure coding practices when writing this code?
None relevant here
