### PR TITLE
Fix ecs deploy dependencies with updated version pins.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/alegre/api:latest"
   only:
     - develop
+    - bugfix/ecs-deploy-versionsfix
 
 deploy_qa:
   image: python:3-alpine
@@ -37,10 +38,10 @@ deploy_qa:
     - apk add --no-cache curl python3 py3-pip git
     - pip install setuptools==75.1.0
     - pip install urllib3==2.0.6
-    - pip install botocore==1.31.62
-    - pip install boto3==1.28.62
+    - pip install botocore==1.31.85
+    - pip install boto3==1.28.85
     - pip install ecs-deploy==1.15.0
-    - pip install awscli==1.31.13
+    - pip install awscli==1.29.85
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/alegre/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/alegre/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-alegre-c $NAME /qa/alegre/$NAME " >> qa-alegre-c.env.args; done
     - ecs deploy ecs-qa  qa-alegre --diff --image qa-alegre-c $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e qa-alegre-c APP alegre -e qa-alegre-c PERSISTENT_DISK_PATH /mnt/models/video -e qa-alegre-c DEPLOY_ENV qa -e qa-alegre-c ALEGRE_PORT 8000 --exclusive-secrets `cat qa-alegre-c.env.args`
@@ -57,6 +58,7 @@ deploy_qa:
     - echo "new Image was deployed $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA"
   only:
     - develop
+    - bugfix/ecs-deploy-versionsfix
 
 build_live:
   image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/alegre/api:latest"
   only:
     - develop
-    - bugfix/ecs-deploy-versionsfix
 
 deploy_qa:
   image: python:3-alpine
@@ -58,7 +57,6 @@ deploy_qa:
     - echo "new Image was deployed $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA"
   only:
     - develop
-    - bugfix/ecs-deploy-versionsfix
 
 build_live:
   image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
@@ -93,10 +91,10 @@ deploy_live:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install setuptools==75.1.0
     - pip install urllib3==2.0.6
-    - pip install botocore==1.31.62
-    - pip install boto3==1.28.62
+    - pip install botocore==1.34.162
+    - pip install boto3==1.34.162
     - pip install ecs-deploy==1.15.0
-    - pip install awscli==1.31.13
+    - pip install awscli==1.33.44
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/alegre/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/alegre/##' > env.live.names
     - for NAME in `cat env.live.names`; do echo -n "-s live-alegre-c $NAME /live/alegre/$NAME " >> live-alegre-c.env.args; done
     - ecs deploy ecs-live  live-alegre --image live-alegre-c $LIVE_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e live-alegre-c APP alegre -e live-alegre-c PERSISTENT_DISK_PATH /mnt/models/video -e live-alegre-c DEPLOY_ENV live -e live-alegre-c ALEGRE_PORT 8000 --exclusive-secrets `cat live-alegre-c.env.args`

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,10 +38,10 @@ deploy_qa:
     - apk add --no-cache curl python3 py3-pip git
     - pip install setuptools==75.1.0
     - pip install urllib3==2.0.6
-    - pip install botocore==1.31.85
-    - pip install boto3==1.28.85
+    - pip install botocore==1.34.162
+    - pip install boto3==1.34.162
     - pip install ecs-deploy==1.15.0
-    - pip install awscli==1.29.85
+    - pip install awscli==1.33.44
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/alegre/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/alegre/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-alegre-c $NAME /qa/alegre/$NAME " >> qa-alegre-c.env.args; done
     - ecs deploy ecs-qa  qa-alegre --diff --image qa-alegre-c $QA_ECR_API_BASE_URL:$CI_COMMIT_SHA --timeout 1200 --exclusive-env -e qa-alegre-c APP alegre -e qa-alegre-c PERSISTENT_DISK_PATH /mnt/models/video -e qa-alegre-c DEPLOY_ENV qa -e qa-alegre-c ALEGRE_PORT 8000 --exclusive-secrets `cat qa-alegre-c.env.args`


### PR DESCRIPTION
## Description
Fix dependencies in the ecs-deploy utility with updated version pins. Required for future deployments.

Reference: [CV2-6218 (to provide additional context)](https://meedan.atlassian.net/browse/CV2-6218)

## How has this been tested?
Fix tested with a successful deployment to QA.

## Have you considered secure coding practices when writing this code?
None.