### PR TITLE
[CV2-6066]  processes from 8 to 16, and removing --threads

### DIFF
--- a/production/bin/start.sh
+++ b/production/bin/start.sh
@@ -66,4 +66,4 @@ set +o allexport
 python manage.py init
 python manage.py init_perl_functions
 python manage.py db upgrade
-gunicorn --preload -w 16 -b 0.0.0.0:${ALEGRE_PORT} --access-logfile - --error-logfile - wsgi:app
+gunicorn --preload -w 16 --threads 16 -b 0.0.0.0:${ALEGRE_PORT} --access-logfile - --error-logfile - wsgi:app

--- a/production/bin/start.sh
+++ b/production/bin/start.sh
@@ -66,4 +66,4 @@ set +o allexport
 python manage.py init
 python manage.py init_perl_functions
 python manage.py db upgrade
-gunicorn --preload -w 8 --threads 16 -b 0.0.0.0:${ALEGRE_PORT} --access-logfile - --error-logfile - wsgi:app
+gunicorn --preload -w 16 -b 0.0.0.0:${ALEGRE_PORT} --access-logfile - --error-logfile - wsgi:app


### PR DESCRIPTION
doubling woker processes from 8 to 16 and removing --threads since gunicorn docs show it is only for gevent, which we are not using yet

## Description
Please include a very brief high-level description of the problem or feature and technical details or specific code changes on PR

Reference: https://meedan.atlassian.net/browse/CV2-6066


