### PR TITLE
[CV2-6066] 4X workerprocesses from 16 to 64 ...

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @DGaffney @skyemeedan @computermacgyver
+* @skyemeedan @computermacgyver
 /.github/ @dmou
 /production/ @dmou
 Dockerfile @dmou

--- a/app/test/test_openai.py
+++ b/app/test/test_openai.py
@@ -73,7 +73,9 @@ class TestRetrieveOpenAIEmbeddings(BaseTestCase):
             result = retrieve_openai_embeddings(self.test_content_sample['content'], self.test_content_sample['models'][0])
             self.assertIsNotNone(openai.api_key)
             self.assertNotEquals(openai.api_key,"")
-            self.assertEqual(result, self.test_content_embedding_true_value)
+            # because the values of the vectors returned by the service may change
+            # we are only checking that they are the expected length
+            self.assertEqual(len(result), len(self.test_content_embedding_true_value))
 
 if __name__ == "__main__":
     unittest.main()

--- a/production/bin/start.sh
+++ b/production/bin/start.sh
@@ -66,4 +66,4 @@ set +o allexport
 python manage.py init
 python manage.py init_perl_functions
 python manage.py db upgrade
-gunicorn --preload -w 16 --threads 16 -b 0.0.0.0:${ALEGRE_PORT} --access-logfile - --error-logfile - wsgi:app
+gunicorn --preload -w 64 --threads 16 -b 0.0.0.0:${ALEGRE_PORT} --max-requests 1000 --max-requests-jitter 100 --access-logfile - --error-logfile - wsgi:app


### PR DESCRIPTION
* Adjust the gunicorn configuration to 4X worker processes from 16 to 64 and also adding max-requests and jitter to restart process to reduce impact of memory growth

https://docs.gunicorn.org/en/stable/settings.html
```
--max-requests INT
Any value greater than zero will limit the number of requests a worker will process before automatically restarting. This is a simple method to help limit the damage of memory leaks.

--max_requests_jitter INT
The maximum jitter to add to the max_requests setting.The jitter causes the restart per worker to be randomized by randint(0, max_requests_jitter). This is intended to stagger worker restarts to avoid all workers restarting at the same time.
```

* also update CODEOWNERS 

Reference: https://meedan.atlassian.net/browse/CV2-6066


