### PR TITLE
[CV2-6066] setting the number of worker processes back to 16

### DIFF
--- a/production/bin/start.sh
+++ b/production/bin/start.sh
@@ -66,4 +66,4 @@ set +o allexport
 python manage.py init
 python manage.py init_perl_functions
 python manage.py db upgrade
-gunicorn --preload -w 64 --threads 16 -b 0.0.0.0:${ALEGRE_PORT} --max-requests 1000 --max-requests-jitter 100 --access-logfile - --error-logfile - wsgi:app
+gunicorn --preload -w 16 --threads 16 -b 0.0.0.0:${ALEGRE_PORT} --access-logfile - --error-logfile - wsgi:app


### PR DESCRIPTION
## Description
Reduces the number of worker threads from 64 (untested) back to 16I realized that I probably won't have time to run tests on the number of worker processes today, I don't want to leave QA in an untested state

Reference: https://meedan.atlassian.net/browse/CV2-6066

