### PR TITLE
CV2-6587 – Remove upload to Code Climate

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -10,9 +10,6 @@ on:
     branches:
     - develop
 
-env:
-  CC_TEST_REPORTER_ID: "${{ secrets.CC_TEST_REPORTER_ID }}"
-
 jobs:
   unit-tests:
     runs-on: 
@@ -60,7 +57,6 @@ jobs:
 
     - name: Set up reporter
       run: |
-        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         chmod +x ./cc-test-reporter
 
     - name: Before script
@@ -83,12 +79,6 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       run: |
        docker compose exec alegre coverage xml
-
-    - name: Upload Coverage Report
-      if: ${{ github.event_name != 'pull_request' }}
-      env:
-         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-      run: ./cc-test-reporter after-build -t coverage.py --exit-code $?
 
     - name: Cleanup Docker Resources
       if: always()
@@ -146,7 +136,6 @@ jobs:
 
     - name: Set up reporter
       run: |
-        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         chmod +x ./cc-test-reporter
 
     - name: Before script


### PR DESCRIPTION
## Description
Code Climate as it was does not exist anymore, so the upload step fails, causing tests to fail. This just removes the upload, does not add a substitution or print the report results. 

Reference: CV2-6587

## How has this been tested?
Has it been tested locally? Are there automated tests?

## Have you considered secure coding practices when writing this code?
Please list any security concerns that may be relevant.
