### PR TITLE
Invoke sysops deployment with image tag for Live updates.

### DIFF
--- a/.github/workflows/ci-deploy-env.yml
+++ b/.github/workflows/ci-deploy-env.yml
@@ -109,4 +109,3 @@ jobs:
       if: ${{ success() || failure() }}
       run: |
         rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/ci-deploy-env.yml
+++ b/.github/workflows/ci-deploy-env.yml
@@ -95,11 +95,18 @@ jobs:
       id: sysops-deploy-live
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       run: |
+        RELEASE_TAG=$(echo "${GITHUB_REF#refs/*/}" | sed 's/.*\///')
         curl --fail-with-body \
         -X POST \
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer ${{ secrets.SYSOPS_RW_GITHUB_TOKEN }}" \
         -H "X-GitHub-Api-Version: 2022-11-28" \ 
         https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_alegre.yml/dispatches \
-        -d '{"ref": "master", "inputs": {"git_sha": "${{ github.sha }}", "type": "tag"}}'
+        -d '{"ref": "master", "inputs": {"image_tag": "'$RELEASE_TAG'", "type": "tag"}}'
 
+    - name: Reset cache
+      id: reset-cache
+      if: ${{ success() || failure() }}
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
## Description

This change adds support for deployment workflow invocation with an image_tag input used for Live cluster updates. This resolves an error where git_sha based deployments lacked sufficient lifecycle policy in ECR to keep services running during ongoing development and CI/CD builds.

See also: https://meedan.atlassian.net/browse/CV2-6664

## Have you considered secure coding practices when writing this code?

No security concerns with this change.